### PR TITLE
chore: update environmentSettings for github actions

### DIFF
--- a/test/environmentSettings.ts
+++ b/test/environmentSettings.ts
@@ -5,14 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import path from 'path';
+import { join } from 'path';
 
 export class EnvironmentSettings {
   private static _instance: EnvironmentSettings;
 
   private _devHubAliasName = 'vscodeOrg';
   private _devHubUserName = 'svc_idee_bot@salesforce.com';
-  private _extensionPath = path.join(__dirname, '..', '..', 'salesforcedx-vscode', 'packages');
+  private _extensionPath = join(__dirname, '..', '..', 'salesforcedx-vscode', 'packages');
   private _throttleFactor = 1;
 
   private constructor() {


### PR DESCRIPTION
In order for the e2e tests to boot up in Github Actions on a Mac, it was necessary to import `join` explicitly, or the dependency could not be found. (Note the tests are still showing as failing since these tests are running without a compile in the VS Code repo to save testing time.)

Example of a [test run](https://github.com/randi274/salesforcedx-vscode-fork/actions/runs/4601378484/jobs/8129159861) where `path` couldn't be located.

This [test run](https://github.com/randi274/salesforcedx-vscode-fork/actions/runs/4601636514/workflow) passed that failure point in another branch where I made a [similar change](https://github.com/forcedotcom/salesforcedx-vscode-automation-tests/compare/develop...randi/gha-setup) in `wdio.conf.ts` to import `join` directly from path.

["Successful" run](https://github.com/randi274/salesforcedx-vscode-fork/actions/runs/4609225343/jobs/8146070667) that passes the `path` failure, in a more ideal state where we don't have separate references to `extensionPath`.