### PR TITLE
Ra/add authorization setup testing org

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,6 +32,16 @@
         "reveal": "always",
         "panel": "new"
       }
+    },
+    {
+      "label": "Authorize DevHub - E2E Testing Org",
+      "type": "shell",
+      "command": "sfdx auth web login | sfdx alias set vscodeOrg=svcideebot@salesforce.com | sfdx org list",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Salesforce Extensions for VS Code
+
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ## Introduction
+
 This repository contains the source code for the automation tests for the Salesforce Extensions for VS Code.
 
 ### WDIO VSCode Service
+
 This project is based on `WDIO VSCode Service, available at https://github.com/webdriverio-community/wdio-vscode-service
 
 ### Getting Started
+
 If you are interested in contributing, please take a look at the [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 After cloning this repo, you will also need to clone https://github.com/forcedotcom/salesforcedx-vscode. The default topography is for `salesforcedx-vscode` and `salesforcedx-vscode-automation-tests` to reside side-by-side in the same parent location.
@@ -19,21 +23,29 @@ For the VSCode extension (`{location}/salesforcedx-vscode`), you will need to ru
 After the dependencies have been installed, open the folder in Visual Studio Code, then debug using the `Debug All Automation Tests` configuration (or run using the `Run All Automation Tests` configuration).
 
 ### Environment Variables
+
 The following is a list of environment variables that are used with this project. Each has a default value and are obtained using the [environmentSettings](test/environmentSettings.ts) class.
 
 #### DEV_HUB_ALIAS_NAME
+
 Default value: `vscodeOrg`
 
 #### DEV_HUB_USER_NAME
-Default value: `svc_idee_bot@salesforce.com`
+
+Default value: `svcideebot@salesforce.com`
 
 #### EXTENSION_PATH
+
 Default value: `{cwd}/../../salesforcedx-vscode/packages`
 
-The default folder structure is `{location}/salesforcedx-vscode` and `{location}/salesforcedx-vscode-automation-tests`, and if both repos are at the same location no changes are needed for `EXTENSION_PATH`.  If your folder structure does not match this, EXTENSION_PATH will need to be set to the relative path to 'salesforcedx-vscode/packages' .
+The default folder structure is `{location}/salesforcedx-vscode` and `{location}/salesforcedx-vscode-automation-tests`, and if both repos are at the same location no changes are needed for `EXTENSION_PATH`. If your folder structure does not match this, EXTENSION_PATH will need to be set to the relative path to 'salesforcedx-vscode/packages' .
 
 #### THROTTLE_FACTOR
+
 Default value: 1
 
 ### Dev Hub
-A requirement of this project is for a dev hub to have been enabled on the user's machine.  The default dev hub name is "vscodeOrg" and the default username is "svc_idee_bot@salesforce.com", though this can be configured with the `DEV_HUB_ALIAS_NAME` and `DEV_HUB_USER_NAME` environment variables.
+
+A requirement of this project is for a dev hub to have been enabled on the user's machine. The default dev hub name is "vscodeOrg" and the default username is "svcideebot@salesforce.com", though this can be configured with the `DEV_HUB_ALIAS_NAME` and `DEV_HUB_USER_NAME` environment variables.
+Run Task : Authorize DevHub - E2E Testing Org through command palette (Cmd+shft+P).
+Once you are connected to the org with `DEV_HUB_ALIAS_NAME` and `DEV_HUB_USER_NAME` you can run single or all end-to-end test suites.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {},
   "scripts": {
     "automation-tests": "wdio run test/wdio.conf.ts",
+    "setup": "wdio run test/wdio.conf.ts --spec test/setup/anInitialSetUp.e2e.ts",
     "commit": "git-cz"
   },
   "husky": {

--- a/test/environmentSettings.ts
+++ b/test/environmentSettings.ts
@@ -32,7 +32,9 @@ export class EnvironmentSettings {
     // './test/specs/**/visualforceLsp.e2e.ts'
   ];
   private _devHubAliasName = 'vscodeOrg';
-  private _devHubUserName = 'svc_idee_bot@salesforce.com';
+  private _devHubUserName = 'svcideebot@salesforce.com';
+  private _sfdxAuthUrl = process.env.SFDX_AUTH_URL;
+  private _orgId = process.env.ORG_ID;
   private _extensionPath = join(
     __dirname,
     '..',
@@ -73,6 +75,12 @@ export class EnvironmentSettings {
       EnvironmentSettings._instance._throttleFactor =
         parseInt(process.env.THROTTLE_FACTOR!) ||
         EnvironmentSettings._instance._throttleFactor;
+      EnvironmentSettings._instance._sfdxAuthUrl = 
+        process.env.SFDXAUTHURL_TEST ||
+      EnvironmentSettings._instance._sfdxAuthUrl;
+      EnvironmentSettings._instance._orgId = 
+        process.env.ORG_ID ||
+      EnvironmentSettings._instance._orgId;
     }
 
     return EnvironmentSettings._instance;
@@ -104,5 +112,13 @@ export class EnvironmentSettings {
 
   public get startTime(): string {
     return this._startTime;
+  }
+
+  public get sfdxAuthUrl(): string | undefined {
+    return this._sfdxAuthUrl;
+  }
+
+  public get orgId(): string | undefined {
+    return this._orgId;
   }
 }

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -47,7 +47,7 @@ describe('An Initial SetUp', async () => {
     const terminalView = await utilities.executeCommand(workbench, 'sfdx org list')
     const terminalText = await utilities.getTerminalViewText(terminalView, 100);
 
-    expect(terminalText).toContain(`${orgId}`);
+    expect(terminalText).toContain(orgId);
     expect(terminalText).toContain('Connected');
     expect(terminalText).toContain('Non-scratch orgs');
     expect(terminalText).toContain(devHubUserName);

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import child_process from 'child_process';
+import fs from 'fs';
+import { step } from "mocha-steps";
+import util from 'util';
+import { EnvironmentSettings } from '../environmentSettings';
+import * as utilities from '../utilities';
+
+const exec = util.promisify(child_process.exec);
+
+describe('An Initial SetUp', async () => {
+  const environmentSettings = EnvironmentSettings.getInstance();
+  const devHubUserName = environmentSettings.devHubUserName;
+  const devHubAliasName = environmentSettings.devHubAliasName;
+  const SFDX_AUTH_URL = environmentSettings.sfdxAuthUrl;
+  const orgId = environmentSettings.orgId;
+
+  step('Countdown', async () => {
+    utilities.log('About to start authorizing to devhub');
+    for (let i = 5; i > 0; i--) {
+      utilities.log(`${i}...`);
+      await utilities.pause(1);
+    }
+  });
+
+  step('Authorize to Testing Org', async () => {
+    const sfdxAuthUrl = String(SFDX_AUTH_URL);
+    const authFilePath = 'authFile.txt';
+
+    // create and write in a text file
+    fs.writeFileSync(authFilePath, sfdxAuthUrl);
+
+    // For sfdx -> sf, remove the two lines below this comment block and uncomment the following line instead
+    // await exec(`sf org login sfdx-url --sfdx-url-file ${authFilePath} --set-default --alias ${devHubAliasName}`);
+    await exec(`sfdx auth:sfdxurl:store -f ${authFilePath}`);
+    await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
+  });
+
+  step('Verify Connection to the Testing Org', async () => {
+    const workbench = await browser.getWorkbench();
+    const terminalView = await utilities.executeCommand(workbench, 'sfdx org list')
+    const terminalText = await utilities.getTerminalViewText(terminalView, 100);
+
+    expect(terminalText).toContain(`${orgId}`);
+    expect(terminalText).toContain('Connected');
+    expect(terminalText).toContain('Non-scratch orgs');
+    expect(terminalText).toContain(`${devHubUserName}`);
+    expect(terminalText).toContain(`${devHubAliasName}`);
+  });
+});

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -50,7 +50,7 @@ describe('An Initial SetUp', async () => {
     expect(terminalText).toContain(`${orgId}`);
     expect(terminalText).toContain('Connected');
     expect(terminalText).toContain('Non-scratch orgs');
-    expect(terminalText).toContain(`${devHubUserName}`);
-    expect(terminalText).toContain(`${devHubAliasName}`);
+    expect(terminalText).toContain(devHubUserName);
+    expect(terminalText).toContain(devHubAliasName);
   });
 });

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -34,6 +34,7 @@ describe('An Initial Suite', async () => {
   });
 
   step('Verify our extensions are not initially loaded', async () => {
+    utilities.pause(5)
     const workbench = await browser.getWorkbench();
     await utilities.showRunningExtensions(workbench);
 


### PR DESCRIPTION
**What does this PR do?**

- Adds an e2e test at `test/setup/ anInitialSetUp.e2e.ts`.
- Adds a script `npm run setup` which runs anInitialSetUp.e2e.ts before running any e2e test.
- The anInitialSetUp.e2e.ts end-to-end test authorizes to a persistent testing org in remote environment like Github Actions using sfdxAuthUrl.
- Adds a task `Authorize DevHub - E2E Testing Org` to initiate local setup required to run end-to-end test.