### PR TITLE
fix: remote run InitialTestSuite

### DIFF
--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -99,11 +99,13 @@ export class TestSetup {
     utilities.log(`${this.testSuiteSuffixName} - Starting createProject()...`);
 
     const workbench = await browser.getWorkbench();
+    utilities.pause(10);
     this.prompt = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Project',
-      10
+      30
     );
+    utilities.pause(10);
     // Selecting "SFDX: Create Project" causes the extension to be loaded, and this takes a while.
 
     // Select the "Standard" project type.


### PR DESCRIPTION
Adding more duration pause while executing `SFDX:Create Project`. Helps the e2e test suite to run successfully.

How To test:

1. Paste this branch in second field i.e. **Set the branch to use for automation tests** of End To End Test manual workflow in salesforcedx-vscode extensions Github Actions. 
2. Choose initialTestSuite.e2e.ts from the drop down to select the test to run.

AC:
All tests within the testsuite should pass.
 