### PR TITLE
Ra/fix initial setup for windows

### DIFF
--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -46,11 +46,16 @@ describe('An Initial SetUp', async () => {
     const workbench = await browser.getWorkbench();
     const terminalView = await utilities.executeCommand(workbench, 'sfdx org list')
     const terminalText = await utilities.getTerminalViewText(terminalView, 100);
-
+    utilities.log(`............${terminalText}....`)
     expect(terminalText).toContain(orgId);
+    utilities.log('...Contains OrgID...');
     expect(terminalText).toContain('Connected');
+    utilities.log('...Contains text Connected...');
     expect(terminalText).toContain('Non-scratch orgs');
+    utilities.log('...Contains text Non-scratch orgs...');
     expect(terminalText).toContain(devHubUserName);
+    utilities.log('...Contains devhubUsername...');
     expect(terminalText).toContain(devHubAliasName);
+    utilities.log('...Contains devhubAlias...');
   });
 });

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -39,31 +39,11 @@ describe('An Initial SetUp', async () => {
     // For sfdx -> sf, remove the two lines below this comment block and uncomment the following line instead
     // await exec(`sf org login sfdx-url --sfdx-url-file ${authFilePath} --set-default --alias ${devHubAliasName}`);
     const authorizeOrg = await exec(`sfdx auth:sfdxurl:store -d -f ${authFilePath}`);
-    utilities.log('....authorized...')
     expect(authorizeOrg.stdout).toContain(`Successfully authorized ${devHubUserName} with org ID ${orgId}`);
-    utilities.log('...verified Authorization....')
 
     const setAlias = await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
-    utilities.log('...set Alias done...')
     expect(setAlias.stdout).toContain(devHubAliasName);
     expect(setAlias.stdout).toContain(devHubUserName);
-    expect(setAlias.stdout).toContain(true);
+    expect(setAlias.stdout).toContain('true');
   });
-
-  // step('Verify Connection to the Testing Org', async () => {
-  //   const workbench = await browser.getWorkbench();
-  //   const terminalView = await utilities.executeCommand(workbench, 'sfdx org list')
-  //   const terminalText = await utilities.getTerminalViewText(terminalView, 100);
-  //   utilities.log(`............${terminalText}....`)
-  //   expect(terminalText).toContain(orgId);
-  //   utilities.log('...Contains OrgID...');
-  //   expect(terminalText).toContain('Connected');
-  //   utilities.log('...Contains text Connected...');
-  //   expect(terminalText).toContain('Non-scratch orgs');
-  //   utilities.log('...Contains text Non-scratch orgs...');
-  //   expect(terminalText).toContain(devHubUserName);
-  //   utilities.log('...Contains devhubUsername...');
-  //   expect(terminalText).toContain(devHubAliasName);
-  //   utilities.log('...Contains devhubAlias...');
-  // });
 });

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -42,20 +42,20 @@ describe('An Initial SetUp', async () => {
     await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
   });
 
-  step('Verify Connection to the Testing Org', async () => {
-    const workbench = await browser.getWorkbench();
-    const terminalView = await utilities.executeCommand(workbench, 'sfdx org list')
-    const terminalText = await utilities.getTerminalViewText(terminalView, 100);
-    utilities.log(`............${terminalText}....`)
-    expect(terminalText).toContain(orgId);
-    utilities.log('...Contains OrgID...');
-    expect(terminalText).toContain('Connected');
-    utilities.log('...Contains text Connected...');
-    expect(terminalText).toContain('Non-scratch orgs');
-    utilities.log('...Contains text Non-scratch orgs...');
-    expect(terminalText).toContain(devHubUserName);
-    utilities.log('...Contains devhubUsername...');
-    expect(terminalText).toContain(devHubAliasName);
-    utilities.log('...Contains devhubAlias...');
-  });
+  // step('Verify Connection to the Testing Org', async () => {
+  //   const workbench = await browser.getWorkbench();
+  //   const terminalView = await utilities.executeCommand(workbench, 'sfdx org list')
+  //   const terminalText = await utilities.getTerminalViewText(terminalView, 100);
+  //   utilities.log(`............${terminalText}....`)
+  //   expect(terminalText).toContain(orgId);
+  //   utilities.log('...Contains OrgID...');
+  //   expect(terminalText).toContain('Connected');
+  //   utilities.log('...Contains text Connected...');
+  //   expect(terminalText).toContain('Non-scratch orgs');
+  //   utilities.log('...Contains text Non-scratch orgs...');
+  //   expect(terminalText).toContain(devHubUserName);
+  //   utilities.log('...Contains devhubUsername...');
+  //   expect(terminalText).toContain(devHubAliasName);
+  //   utilities.log('...Contains devhubAlias...');
+  // });
 });

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -38,9 +38,16 @@ describe('An Initial SetUp', async () => {
 
     // For sfdx -> sf, remove the two lines below this comment block and uncomment the following line instead
     // await exec(`sf org login sfdx-url --sfdx-url-file ${authFilePath} --set-default --alias ${devHubAliasName}`);
-    await exec(`sfdx auth:sfdxurl:store -d -f ${authFilePath}`);
+    const authorizeOrg = await exec(`sfdx auth:sfdxurl:store -d -f ${authFilePath}`);
+    utilities.log('....authorized...')
+    expect(authorizeOrg.stdout).toContain(`Successfully authorized ${devHubUserName} with org ID ${orgId}`);
+    utilities.log('...verified Authorization....')
+
     const setAlias = await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
-    utilities.log(`...${setAlias.stdout}...`)
+    utilities.log('...set Alias done...')
+    expect(setAlias.stdout).toContain(devHubAliasName);
+    expect(setAlias.stdout).toContain(devHubUserName);
+    expect(setAlias.stdout).toContain(true);
   });
 
   // step('Verify Connection to the Testing Org', async () => {

--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -38,8 +38,9 @@ describe('An Initial SetUp', async () => {
 
     // For sfdx -> sf, remove the two lines below this comment block and uncomment the following line instead
     // await exec(`sf org login sfdx-url --sfdx-url-file ${authFilePath} --set-default --alias ${devHubAliasName}`);
-    await exec(`sfdx auth:sfdxurl:store -f ${authFilePath}`);
-    await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
+    await exec(`sfdx auth:sfdxurl:store -d -f ${authFilePath}`);
+    const setAlias = await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
+    utilities.log(`...${setAlias.stdout}...`)
   });
 
   // step('Verify Connection to the Testing Org', async () => {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -99,7 +99,7 @@ export class TestSetup {
     utilities.log(`${this.testSuiteSuffixName} - Starting createProject()...`);
 
     const workbench = await browser.getWorkbench();
-    utilities.pause(10);
+    utilities.pause(15);
     this.prompt = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Project',


### PR DESCRIPTION
This PR 
- runs the very first script required to run e2e on any environment : `npm run setup` successfully on all os environments
- removes third verification step from initialSetup where it was reading text from terminal view. The method used is using key strokes to select all and copy which doesn't run on windows and ubuntu.
So Modifying the tests to use stdout of command executed in shell to verify the authorization to devhub.

How To test:

Paste the PR's branch in second field i.e. `Set the branch to use for automation tests` of End To End Test manual workflow in salesforcedx-vscode extensions Github Actions.
Choose initialSuite.e2e.ts to run from the drop down options.

AC:
anInitialSetUp should pass on all three jobs.

Reference: [run #54](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5605860550)