### PR TITLE
fix for TestSetup.setUp() 

### DIFF
--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -24,7 +24,7 @@ describe('Visualforce LSP', async () => {
 
     utilities.log(`${testSetup.testSuiteSuffixName} - calling createVisualforcePage()`);
     // Clear output before running the command
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     // Create Visualforce Page
     await utilities.createVisualforcePage();
@@ -63,7 +63,7 @@ describe('Visualforce LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Verify Extension is Running`);
 
     // Using the Command palette, run Developer: Show Running Extensions
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.showRunningExtensions(workbench);
 
     // Verify Visualforce extension is present and running
@@ -77,7 +77,7 @@ describe('Visualforce LSP', async () => {
   step('Go to Definition', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('FooPage.page')) as TextEditor;
     await textEditor.moveCursor(1, 25);
@@ -97,7 +97,7 @@ describe('Visualforce LSP', async () => {
   step('Autocompletion', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('FooPage.page')) as TextEditor;
     await textEditor.typeTextAt(3, 1, '\t\t<apex:pageM');

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -37,10 +37,14 @@ export class TestSetup {
   }
 
   public async setUp(scratchOrgEdition: string = 'Developer'): Promise<void> {
+    utilities.log('');
+    utilities.log(`${this.testSuiteSuffixName} - Starting TestSetup.setUp()...`);
     await this.setUpTestingEnvironment();
     await this.createProject(scratchOrgEdition);
     await this.authorizeDevHub();
     await this.createDefaultScratchOrg();
+    utilities.log(`${this.testSuiteSuffixName} - ...finished TestSetup.setUp()`);
+    utilities.log('');
   }
 
   public async tearDown(): Promise<void> {
@@ -98,14 +102,13 @@ export class TestSetup {
     utilities.log('');
     utilities.log(`${this.testSuiteSuffixName} - Starting createProject()...`);
 
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     utilities.pause(15);
     this.prompt = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Project',
-      30
+      50
     );
-    utilities.pause(10);
     // Selecting "SFDX: Create Project" causes the extension to be loaded, and this takes a while.
 
     // Select the "Standard" project type.
@@ -127,9 +130,11 @@ export class TestSetup {
     await utilities.clickFilePathOkButton();
 
     // Verify the project was created and was loaded.
-    const sidebar = await workbench.getSideBar();
-    const content = await sidebar.getContent();
-    const treeViewSection = await content.getSection(this.tempProjectName.toUpperCase());
+    const sidebar = await (await workbench.getSideBar()).wait();
+    const content = await (await sidebar.getContent()).wait();
+    const treeViewSection = await (
+      await content.getSection(this.tempProjectName.toUpperCase())
+    ).wait();
     if (!treeViewSection) {
       throw new Error(
         'In createProject(), getSection() returned a treeViewSection with a value of null (or undefined)'
@@ -250,7 +255,7 @@ export class TestSetup {
     const currentOsUserName = await utilities.transformedUserName();
 
     utilities.log(`${this.testSuiteSuffixName} - calling getWorkbench()...`);
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
 
     if (this.reuseScratchOrg) {
       utilities.log(`${this.testSuiteSuffixName} - looking for a scratch org to reuse...`);
@@ -343,7 +348,7 @@ export class TestSetup {
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Set a Default Org',
-      1
+      10
     );
 
     utilities.log(`${this.testSuiteSuffixName} - calling findQuickPickItem()...`);


### PR DESCRIPTION
In this PR I increase the pause after the creation of a project so TestSetup.setUp() passes
Successful runs:
- [5660238387](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5660238387)
- [5660324254](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5660324254)
- [5660325441](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5660325441)
- Set up the testing environment passing on all suites in [run 15339140679](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5660531888/job/15339140679)

@W-13743884@