### PR TITLE
Fixes for deploy and retrieve on remote GHA

### DIFF
--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -349,7 +349,7 @@ describe('Deploy and Retrieve', async () => {
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, `\t// let's trigger deploy`);
     await textEditor.save();
-    await utilities.pause(1);
+    await utilities.pause(5);
     // Wait for the command to execute
     await utilities.waitForNotificationToGoAway(
       workbench,
@@ -422,7 +422,7 @@ describe('Deploy and Retrieve', async () => {
     await enableSourceTrackingBtn.click();
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
-    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 50);
+    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 40);
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -319,7 +319,7 @@ describe('Deploy and Retrieve', async () => {
     await utilities.runCommandFromCommandPrompt(
       workbench,
       'Preferences: Open Workspace Settings',
-      5
+      3
     );
     await browser.keys(['p', 'u', 's', 'h', 'Space', 'o', 'n', 'Space', 's', 'a', 'v', 'e']);
 
@@ -327,13 +327,20 @@ describe('Deploy and Retrieve', async () => {
       'div[title="salesforcedx-vscode-core.push-or-deploy-on-save.enabled"]'
     );
     await pushOrDeployOnSaveBtn.click();
-    await utilities.pause(5);
+    await utilities.pause(3);
+
+    await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'Preferences: Open Workspace Settings',
+      3
+    );
+    await browser.keys(['p', 'r', 'e', 'f', 'e', 'r', 'Space', 'd', 'e', 'p', 'l', 'o', 'y']);
 
     const preferDeployOnSaveBtn = await $(
       'div[title="salesforcedx-vscode-core.push-or-deploy-on-save.preferDeployOnSave"]'
     );
     await preferDeployOnSaveBtn.click();
-    await utilities.pause(5);
+    await utilities.pause(3);
 
     // Clear all notifications so clear output button is reachable
     await utilities.runCommandFromCommandPrompt(

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -327,13 +327,13 @@ describe('Deploy and Retrieve', async () => {
       'div[title="salesforcedx-vscode-core.push-or-deploy-on-save.enabled"]'
     );
     await pushOrDeployOnSaveBtn.click();
-    await utilities.pause(1);
+    await utilities.pause(5);
 
     const preferDeployOnSaveBtn = await $(
       'div[title="salesforcedx-vscode-core.push-or-deploy-on-save.preferDeployOnSave"]'
     );
     await preferDeployOnSaveBtn.click();
-    await utilities.pause(1);
+    await utilities.pause(5);
 
     // Clear all notifications so clear output button is reachable
     await utilities.runCommandFromCommandPrompt(
@@ -355,7 +355,7 @@ describe('Deploy and Retrieve', async () => {
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Running SFDX: Deploy Source to Org',
-      utilities.FIVE_MINUTES + 120
+      utilities.FIVE_MINUTES
     );
     // At this point there should be no conflicts since this is a new class.
     const successNotificationWasFound = await utilities.notificationIsPresent(

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -349,13 +349,14 @@ describe('Deploy and Retrieve', async () => {
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, `\t// let's trigger deploy`);
     await textEditor.save();
-    await utilities.pause(10);
+    await utilities.pause(5);
     // Wait for the command to execute
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Running SFDX: Deploy Source to Org',
       utilities.FIVE_MINUTES
     );
+    await utilities.pause(15);
     // At this point there should be no conflicts since this is a new class.
     const successNotificationWasFound = await utilities.notificationIsPresent(
       workbench,

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -422,7 +422,7 @@ describe('Deploy and Retrieve', async () => {
     await enableSourceTrackingBtn.click();
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
-    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
+    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 50);
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -364,6 +364,7 @@ describe('Deploy and Retrieve', async () => {
       'Running SFDX: Deploy Source to Org',
       utilities.FIVE_MINUTES
     );
+    await utilities.pause(5);
     // At this point there should be no conflicts since this is a new class.
     const successNotificationWasFound = await utilities.notificationIsPresent(
       workbench,

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -349,7 +349,7 @@ describe('Deploy and Retrieve', async () => {
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, `\t// let's trigger deploy`);
     await textEditor.save();
-    await utilities.pause(5);
+    await utilities.pause(10);
     // Wait for the command to execute
     await utilities.waitForNotificationToGoAway(
       workbench,
@@ -422,7 +422,7 @@ describe('Deploy and Retrieve', async () => {
     await enableSourceTrackingBtn.click();
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
-    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 40);
+    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 50);
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -356,7 +356,6 @@ describe('Deploy and Retrieve', async () => {
       'Running SFDX: Deploy Source to Org',
       utilities.FIVE_MINUTES
     );
-    await utilities.pause(15);
     // At this point there should be no conflicts since this is a new class.
     const successNotificationWasFound = await utilities.notificationIsPresent(
       workbench,

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -286,6 +286,7 @@ describe('Deploy and Retrieve', async () => {
       'Running SFDX: Retrieve Source from Org',
       utilities.FIVE_MINUTES
     );
+    await utilities.pause(3);
     const successNotificationWasFound = await utilities.notificationIsPresent(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran'

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -422,7 +422,7 @@ describe('Deploy and Retrieve', async () => {
     await enableSourceTrackingBtn.click();
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
-    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 10);
+    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -355,7 +355,7 @@ describe('Deploy and Retrieve', async () => {
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Running SFDX: Deploy Source to Org',
-      utilities.FIVE_MINUTES
+      utilities.FIVE_MINUTES + 120
     );
     // At this point there should be no conflicts since this is a new class.
     const successNotificationWasFound = await utilities.notificationIsPresent(


### PR DESCRIPTION
Makes sure deployAndRetrieve.e2e.ts successfully passes on remote GHA

How to test:
Go to the [End to End Tests Workflow](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/e2e.yml) in salesforcedx-vscode repo
Paste the PR's branch (cristi/dr-on-remote) in the second field of the Run workflow dropdown (Set the branch to use for automation tests)
Choose deployAndRetrieve.e2e.ts test from the dropdown to select the test to run.
AC:
Test suite should pass.

Successful runs:
- [158](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5813955391)
- [175](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5824046171)
- [176](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5824327251)
- [177ish](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5824340015)

@W-13743993@