### PR TITLE
Fixes for Templates on remote

### DIFF
--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -169,7 +169,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
+    const textGeneratedFromTemplate = await textEditor.getText();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -287,7 +287,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
+    const textGeneratedFromTemplate = await textEditor.getText();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -93,7 +93,7 @@ describe('Templates', async () => {
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexClass1.cls')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
+    const textGeneratedFromTemplate = await textEditor.getText();
     await utilities.log('textGeneratedFromTemplate:');
     await utilities.log(textGeneratedFromTemplate);
     await utilities.log('expectedText:');

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -93,11 +93,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexClass1.cls')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
-    await utilities.log('textGeneratedFromTemplate:');
-    await utilities.log(textGeneratedFromTemplate);
-    await utilities.log('expectedText:');
-    await utilities.log(expectedText);
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -173,7 +169,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -291,7 +287,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -352,7 +348,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraComponent1.cmp')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -412,7 +408,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraEvent1.evt')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -490,7 +486,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraInterface1.intf')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -553,7 +549,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lightningWebComponent1.js')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -631,7 +627,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforceCmp1.component')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
@@ -709,7 +705,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforcePage1.page')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -25,7 +25,7 @@ describe('Templates', async () => {
   // Apex Class
   step('Create an Apex Class', async () => {
     // Using the Command palette, run SFDX: Create Apex Class.
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Apex Class',
@@ -90,10 +90,10 @@ describe('Templates', async () => {
       '    }',
       '}'
     ].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexClass1.cls')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     await utilities.log('textGeneratedFromTemplate:');
     await utilities.log(textGeneratedFromTemplate);
     await utilities.log('expectedText:');
@@ -101,44 +101,10 @@ describe('Templates', async () => {
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Apex Class', async () => {
-    // Run "SFDX: Push Source to Default Org".
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  ApexClass1  ApexClass');
-
-    const classPath = path.join('force-app', 'main', 'default', 'classes', 'ApexClass1.cls');
-    expect(outputPanelText).toContain(classPath);
-
-    const metadataPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'classes',
-      'ApexClass1.cls-meta.xml'
-    );
-    expect(outputPanelText).toContain(metadataPath);
-  });
-
   // Apex Trigger
   step('Create an Apex Trigger', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Apex Trigger".
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
@@ -204,66 +170,17 @@ describe('Templates', async () => {
   step('Verify the contents of the Apex Trigger', async () => {
     // Verify the default trigger.
     const expectedText = ['trigger ApexTrigger1 on SOBJECT (before insert) {', '', '}'].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Apex Trigger', async () => {
-    // Update the trigger to use the Account SObject.
-    const workbench = await browser.getWorkbench();
-    const editorView = await workbench.getEditorView();
-    const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
-
-    const content = ['trigger ApexTrigger1 on Account (after insert) {', '', '}'].join('\n');
-    await textEditor.setText(content);
-    await textEditor.save();
-
-    // Clear the output before running the command.
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  ApexTrigger1  ApexTrigger');
-
-    const triggerPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'triggers',
-      'ApexTrigger1.trigger'
-    );
-    expect(outputPanelText).toContain(triggerPath);
-
-    const metadataPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'triggers',
-      'ApexTrigger1.trigger-meta.xml'
-    );
-    expect(outputPanelText).toContain(metadataPath);
-  });
-
   // Aura App
   step('Create an Aura App', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Aura App".
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
@@ -371,99 +288,17 @@ describe('Templates', async () => {
   step('Verify the contents of the Aura App', async () => {
     // Verify the default code for an Aura App.
     const expectedText = ['<aura:application>', '', '</aura:application>'].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Aura App', async () => {
-    // Clear the output before running the command.
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  AuraApp1   AuraDefinitionBundle');
-
-    const appPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.app');
-    expect(outputPanelText).toContain(appPath);
-
-    const docPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraApp1',
-      'AuraApp1.auradoc'
-    );
-    expect(outputPanelText).toContain(docPath);
-
-    const cssPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.css');
-    expect(outputPanelText).toContain(cssPath);
-
-    const svgPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.svg');
-    expect(outputPanelText).toContain(svgPath);
-
-    const controllerPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraApp1',
-      'AuraApp1Controller.js'
-    );
-    expect(outputPanelText).toContain(controllerPath);
-
-    const helperPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraApp1',
-      'AuraApp1Helper.js'
-    );
-    expect(outputPanelText).toContain(helperPath);
-
-    const rendererPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraApp1',
-      'AuraApp1Renderer.js'
-    );
-    expect(outputPanelText).toContain(rendererPath);
-
-    const metadataPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraApp1',
-      'AuraApp1.app-meta.xml'
-    );
-    expect(outputPanelText).toContain(metadataPath);
-  });
-
   // Aura Component
   step('Create an Aura Component', async () => {
     // Using the Command palette, run SFDX: Create Aura Component.
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Aura Component',
@@ -514,39 +349,17 @@ describe('Templates', async () => {
 
   step('Verify the contents of the Aura Component', async () => {
     const expectedText = ['<aura:component>', '', '</aura:component>'].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraComponent1.cmp')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Aura Component', async () => {
-    // Run "SFDX: Push Source to Default Org".
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  auraComponent1  AuraDefinitionBundle');
-  });
-
   // Aura Event
   step('Create an Aura Event', async () => {
     // Using the Command palette, run SFDX: Create Aura Component.
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Aura Event',
@@ -596,39 +409,17 @@ describe('Templates', async () => {
     const expectedText = ['<aura:event type="APPLICATION" description="Event template"/>'].join(
       '\n'
     );
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraEvent1.evt')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Aura Event', async () => {
-    // Run "SFDX: Push Source to Default Org".
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  auraEvent1  AuraDefinitionBundle');
-  });
-
   // Aura Interface
   step('Create an Aura Interface', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Aura Interface".
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
@@ -696,60 +487,17 @@ describe('Templates', async () => {
       '  <aura:attribute name="example" type="String" default="" description="An example attribute."/>',
       '</aura:interface>'
     ].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraInterface1.intf')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Aura Interface', async () => {
-    // Clear the output before running the command.
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  AuraInterface1  AuraDefinitionBundle');
-
-    const interfacePath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraInterface1',
-      'AuraInterface1.intf'
-    );
-    expect(outputPanelText).toContain(interfacePath);
-
-    const metadataPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'aura',
-      'AuraInterface1',
-      'AuraInterface1.intf-meta.xml'
-    );
-    expect(outputPanelText).toContain(metadataPath);
-  });
-
   // Lightning Web Component
   step('Create Lightning Web Component', async () => {
     // Using the Command palette, run SFDX: Create Lightning Web Component.
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Create Lightning Web Component',
@@ -802,39 +550,17 @@ describe('Templates', async () => {
       '',
       'export default class LightningWebComponent1 extends LightningElement {}'
     ].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lightningWebComponent1.js')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Lightning Web Component', async () => {
-    // Run "SFDX: Push Source to Default Org".
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  lightningWebComponent1  LightningComponentBundle');
-  });
-
   // Visualforce Component
   step('Create a Visualforce Component', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Visualforce Component".
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
@@ -902,58 +628,17 @@ describe('Templates', async () => {
       '<!-- End Default Content REMOVE THIS -->',
       '</apex:component>'
     ].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforceCmp1.component')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
-  step('Push the Visualforce Component', async () => {
-    // Clear the output before running the command.
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  VisualforceCmp1  ApexComponent');
-
-    const componentPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'components',
-      'VisualforceCmp1.component'
-    );
-    expect(outputPanelText).toContain(componentPath);
-
-    const metadataPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'components',
-      'VisualforceCmp1.component-meta.xml'
-    );
-    expect(outputPanelText).toContain(metadataPath);
-  });
-
   // Visualforce Page
   step('Create a Visualforce Page', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Visualforce Page".
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     const inputBox = await utilities.runCommandFromCommandPrompt(
       workbench,
@@ -1021,52 +706,11 @@ describe('Templates', async () => {
       '<!-- End Default Content REMOVE THIS -->',
       '</apex:page>'
     ].join('\n');
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforcePage1.page')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
-  });
-
-  step('Push the Visualforce Page', async () => {
-    // Clear the output before running the command.
-    const workbench = await browser.getWorkbench();
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
-
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
-      workbench,
-      'SFDX: Push Source to Default Org successfully ran',
-      10
-    );
-    expect(successNotificationWasFound).toBe(true);
-
-    // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText(
-      'Salesforce CLI',
-      '=== Pushed Source',
-      10
-    );
-    expect(outputPanelText).not.toBeUndefined();
-    expect(outputPanelText).toContain('Created  VisualforcePage1  ApexPage');
-
-    const visualforcePagePath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'pages',
-      'VisualforcePage1.page'
-    );
-    expect(outputPanelText).toContain(visualforcePagePath);
-
-    const metadataPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'pages',
-      'VisualforcePage1.page-meta.xml'
-    );
-    expect(outputPanelText).toContain(metadataPath);
   });
 
   // Tear down

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -5,16 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  step
-} from 'mocha-steps';
+import { step } from 'mocha-steps';
 import path from 'path';
-import {
-  TextEditor
-} from 'wdio-vscode-service';
-import {
-  TestSetup
-} from '../testSetup';
+import { TextEditor } from 'wdio-vscode-service';
+import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
 
 describe('Templates', async () => {
@@ -32,7 +26,11 @@ describe('Templates', async () => {
   step('Create an Apex Class', async () => {
     // Using the Command palette, run SFDX: Create Apex Class.
     const workbench = await browser.getWorkbench();
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Class', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Apex Class',
+      1
+    );
 
     // Set the name of the new component to ApexClass1.
     await inputBox.setText('ApexClass1');
@@ -42,16 +40,30 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Apex Class successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Apex Class successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Apex Class', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Apex Class',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
     const classPath = path.join('force-app', 'main', 'default', 'classes', 'ApexClass1.cls');
     expect(outputPanelText).toContain(`create ${classPath}`);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'classes', 'ApexClass1.cls-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'classes',
+      'ApexClass1.cls-meta.xml'
+    );
     expect(outputPanelText).toContain(`create ${metadataPath}`);
 
     // Check for expected items in the Explorer view.
@@ -60,7 +72,11 @@ describe('Templates', async () => {
     await treeViewSection.expand();
 
     // Get the matching (visible) items within the tree which contains "ApexClass1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'ApexClass1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'ApexClass1'
+    );
 
     expect(filteredTreeViewItems.includes('ApexClass1.cls')).toBe(true);
     expect(filteredTreeViewItems.includes('ApexClass1.cls-meta.xml')).toBe(true);
@@ -76,8 +92,12 @@ describe('Templates', async () => {
     ].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('ApexClass1.cls') as TextEditor;
+    const textEditor = (await editorView.openEditor('ApexClass1.cls')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
+    await utilities.log('textGeneratedFromTemplate:');
+    await utilities.log(textGeneratedFromTemplate);
+    await utilities.log('expectedText:');
+    await utilities.log(expectedText);
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
 
@@ -86,18 +106,32 @@ describe('Templates', async () => {
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  ApexClass1  ApexClass');
 
     const classPath = path.join('force-app', 'main', 'default', 'classes', 'ApexClass1.cls');
     expect(outputPanelText).toContain(classPath);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'classes', 'ApexClass1.cls-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'classes',
+      'ApexClass1.cls-meta.xml'
+    );
     expect(outputPanelText).toContain(metadataPath);
   });
 
@@ -106,7 +140,11 @@ describe('Templates', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Apex Trigger".
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Trigger', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Apex Trigger',
+      1
+    );
 
     // Set the name of the new component to ApexTrigger1.
     await inputBox.setText('ApexTrigger1');
@@ -116,16 +154,36 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Apex Trigger successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Apex Trigger successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Apex Trigger', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Apex Trigger',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
-    const triggerPath = path.join('force-app', 'main', 'default', 'triggers', 'ApexTrigger1.trigger');
+    const triggerPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'triggers',
+      'ApexTrigger1.trigger'
+    );
     expect(outputPanelText).toContain(`create ${triggerPath}`);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'triggers', 'ApexTrigger1.trigger-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'triggers',
+      'ApexTrigger1.trigger-meta.xml'
+    );
     expect(outputPanelText).toContain(`create ${metadataPath}`);
 
     // Check for expected items in the Explorer view.
@@ -134,21 +192,21 @@ describe('Templates', async () => {
     await treeViewSection.expand();
 
     // Get the matching (visible) items within the tree which contains "ApexTrigger1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'ApexTrigger1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'ApexTrigger1'
+    );
     expect(filteredTreeViewItems.includes('ApexTrigger1.trigger')).toBe(true);
     expect(filteredTreeViewItems.includes('ApexTrigger1.trigger-meta.xml')).toBe(true);
   });
 
   step('Verify the contents of the Apex Trigger', async () => {
     // Verify the default trigger.
-    const expectedText = [
-      'trigger ApexTrigger1 on SOBJECT (before insert) {',
-      '',
-      '}'
-    ].join('\n');
+    const expectedText = ['trigger ApexTrigger1 on SOBJECT (before insert) {', '', '}'].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('ApexTrigger1.trigger') as TextEditor;
+    const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -157,13 +215,9 @@ describe('Templates', async () => {
     // Update the trigger to use the Account SObject.
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('ApexTrigger1.trigger') as TextEditor;
+    const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
 
-    const content = [
-      'trigger ApexTrigger1 on Account (after insert) {',
-      '',
-      '}'
-    ].join('\n');
+    const content = ['trigger ApexTrigger1 on Account (after insert) {', '', '}'].join('\n');
     await textEditor.setText(content);
     await textEditor.save();
 
@@ -171,18 +225,38 @@ describe('Templates', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  ApexTrigger1  ApexTrigger');
 
-    const triggerPath = path.join('force-app', 'main', 'default', 'triggers', 'ApexTrigger1.trigger');
+    const triggerPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'triggers',
+      'ApexTrigger1.trigger'
+    );
     expect(outputPanelText).toContain(triggerPath);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'triggers', 'ApexTrigger1.trigger-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'triggers',
+      'ApexTrigger1.trigger-meta.xml'
+    );
     expect(outputPanelText).toContain(metadataPath);
   });
 
@@ -191,7 +265,11 @@ describe('Templates', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Aura App".
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Aura App', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Aura App',
+      1
+    );
 
     // Set the name of the new component to AuraApp1.
     await inputBox.setText('AuraApp1');
@@ -201,19 +279,41 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Aura App successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Aura App successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Aura App', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Aura App',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
     const appPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.app');
     expect(outputPanelText).toContain(`create ${appPath}`);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.app-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1.app-meta.xml'
+    );
     expect(outputPanelText).toContain(`create ${metadataPath}`);
 
-    const docPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.auradoc');
+    const docPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1.auradoc'
+    );
     expect(outputPanelText).toContain(`create ${docPath}`);
 
     const cssPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.css');
@@ -222,17 +322,42 @@ describe('Templates', async () => {
     const svgPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.svg');
     expect(outputPanelText).toContain(`create ${svgPath}`);
 
-    const controllerPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1Controller.js');
+    const controllerPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1Controller.js'
+    );
     expect(outputPanelText).toContain(`create ${controllerPath}`);
 
-    const helperPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1Helper.js');
+    const helperPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1Helper.js'
+    );
     expect(outputPanelText).toContain(`create ${helperPath}`);
 
-    const rendererPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1Renderer.js');
+    const rendererPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1Renderer.js'
+    );
     expect(outputPanelText).toContain(`create ${rendererPath}`);
 
     // Get the matching (visible) items within the tree which contains "AuraApp1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'AuraApp1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'AuraApp1'
+    );
     expect(filteredTreeViewItems.includes('AuraApp1.app')).toBe(true);
     expect(filteredTreeViewItems.includes('AuraApp1.app-meta.xml')).toBe(true);
     expect(filteredTreeViewItems.includes('AuraApp1.auradoc')).toBe(true);
@@ -245,14 +370,10 @@ describe('Templates', async () => {
 
   step('Verify the contents of the Aura App', async () => {
     // Verify the default code for an Aura App.
-    const expectedText = [
-      '<aura:application>',
-      '',
-      '</aura:application>'
-    ].join('\n');
+    const expectedText = ['<aura:application>', '', '</aura:application>'].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('AuraApp1.app') as TextEditor;
+    const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -263,18 +384,33 @@ describe('Templates', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  AuraApp1   AuraDefinitionBundle');
 
     const appPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.app');
     expect(outputPanelText).toContain(appPath);
 
-    const docPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.auradoc');
+    const docPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1.auradoc'
+    );
     expect(outputPanelText).toContain(docPath);
 
     const cssPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.css');
@@ -283,16 +419,44 @@ describe('Templates', async () => {
     const svgPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.svg');
     expect(outputPanelText).toContain(svgPath);
 
-    const controllerPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1Controller.js');
+    const controllerPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1Controller.js'
+    );
     expect(outputPanelText).toContain(controllerPath);
 
-    const helperPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1Helper.js');
+    const helperPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1Helper.js'
+    );
     expect(outputPanelText).toContain(helperPath);
 
-    const rendererPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1Renderer.js');
+    const rendererPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1Renderer.js'
+    );
     expect(outputPanelText).toContain(rendererPath);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'aura', 'AuraApp1', 'AuraApp1.app-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraApp1',
+      'AuraApp1.app-meta.xml'
+    );
     expect(outputPanelText).toContain(metadataPath);
   });
 
@@ -300,7 +464,11 @@ describe('Templates', async () => {
   step('Create an Aura Component', async () => {
     // Using the Command palette, run SFDX: Create Aura Component.
     const workbench = await browser.getWorkbench();
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Aura Component', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Aura Component',
+      1
+    );
 
     // Set the name of the new component to auraComponent1.
     await inputBox.setText('auraComponent1');
@@ -310,14 +478,26 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Aura Component successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Aura Component successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Aura Component', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Aura Component',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
     // Check for the presence of the directory, "auraComponent1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'auraComponent1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'auraComponent1'
+    );
     expect(filteredTreeViewItems.includes('auraComponent1')).toBe(true);
 
     // It's a tree, but it's also a list.  Everything in the view is actually flat
@@ -333,14 +513,10 @@ describe('Templates', async () => {
   });
 
   step('Verify the contents of the Aura Component', async () => {
-    const expectedText = [
-      '<aura:component>',
-      '',
-      '</aura:component>'
-    ].join('\n');
+    const expectedText = ['<aura:component>', '', '</aura:component>'].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('auraComponent1.cmp') as TextEditor;
+    const textEditor = (await editorView.openEditor('auraComponent1.cmp')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -350,11 +526,19 @@ describe('Templates', async () => {
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  auraComponent1  AuraDefinitionBundle');
   });
@@ -363,7 +547,11 @@ describe('Templates', async () => {
   step('Create an Aura Event', async () => {
     // Using the Command palette, run SFDX: Create Aura Component.
     const workbench = await browser.getWorkbench();
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Aura Event', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Aura Event',
+      1
+    );
 
     // Set the name of the new component to auraComponent1.
     await inputBox.setText('auraEvent1');
@@ -373,10 +561,18 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Aura Event successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Aura Event successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Aura Event', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Aura Event',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
     // Check for expected items in the Explorer view.
@@ -385,7 +581,11 @@ describe('Templates', async () => {
     await treeViewSection.expand();
 
     // Check for the presence of the directory, "auraEvent1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'auraEvent1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'auraEvent1'
+    );
     expect(filteredTreeViewItems.includes('auraEvent1')).toBe(true);
 
     expect(filteredTreeViewItems.includes('auraEvent1.evt')).toBe(true);
@@ -393,12 +593,12 @@ describe('Templates', async () => {
   });
 
   step('Verify the contents of the Aura Event', async () => {
-    const expectedText = [
-      '<aura:event type="APPLICATION" description="Event template"/>'
-    ].join('\n');
+    const expectedText = ['<aura:event type="APPLICATION" description="Event template"/>'].join(
+      '\n'
+    );
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('auraEvent1.evt') as TextEditor;
+    const textEditor = (await editorView.openEditor('auraEvent1.evt')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -408,11 +608,19 @@ describe('Templates', async () => {
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  auraEvent1  AuraDefinitionBundle');
   });
@@ -422,7 +630,11 @@ describe('Templates', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Aura Interface".
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Aura Interface', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Aura Interface',
+      1
+    );
 
     // Set the name of the new interface to AuraInterface1.
     await inputBox.setText('AuraInterface1');
@@ -432,20 +644,46 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Aura Interface successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Aura Interface successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Aura Interface', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Aura Interface',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
-    const interfacePath = path.join('force-app', 'main', 'default', 'aura', 'AuraInterface1', 'AuraInterface1.intf');
+    const interfacePath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraInterface1',
+      'AuraInterface1.intf'
+    );
     expect(outputPanelText).toContain(`create ${interfacePath}`);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'aura', 'AuraInterface1', 'AuraInterface1.intf-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraInterface1',
+      'AuraInterface1.intf-meta.xml'
+    );
     expect(outputPanelText).toContain(`create ${metadataPath}`);
 
     // Get the matching (visible) items within the tree which contains "AuraInterface1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'AuraInterface1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'AuraInterface1'
+    );
 
     expect(filteredTreeViewItems.includes('AuraInterface1.intf')).toBe(true);
     expect(filteredTreeViewItems.includes('AuraInterface1.intf-meta.xml')).toBe(true);
@@ -460,7 +698,7 @@ describe('Templates', async () => {
     ].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('AuraInterface1.intf') as TextEditor;
+    const textEditor = (await editorView.openEditor('AuraInterface1.intf')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -471,18 +709,40 @@ describe('Templates', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  AuraInterface1  AuraDefinitionBundle');
 
-    const interfacePath = path.join('force-app', 'main', 'default', 'aura', 'AuraInterface1', 'AuraInterface1.intf');
+    const interfacePath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraInterface1',
+      'AuraInterface1.intf'
+    );
     expect(outputPanelText).toContain(interfacePath);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'aura', 'AuraInterface1', 'AuraInterface1.intf-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'aura',
+      'AuraInterface1',
+      'AuraInterface1.intf-meta.xml'
+    );
     expect(outputPanelText).toContain(metadataPath);
   });
 
@@ -490,7 +750,11 @@ describe('Templates', async () => {
   step('Create Lightning Web Component', async () => {
     // Using the Command palette, run SFDX: Create Lightning Web Component.
     const workbench = await browser.getWorkbench();
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Lightning Web Component', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Lightning Web Component',
+      1
+    );
 
     // Set the name of the new component to lightningWebComponent1.
     await inputBox.setText('lightningWebComponent1');
@@ -500,10 +764,18 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Lightning Web Component successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Lightning Web Component successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Lightning Web Component', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Lightning Web Component',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
     // Check for expected items in the Explorer view.
@@ -512,7 +784,11 @@ describe('Templates', async () => {
     await treeViewSection.expand();
 
     // Check for the presence of the directory, "lightningWebComponent1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'lightningWebComponent1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'lightningWebComponent1'
+    );
     expect(filteredTreeViewItems.includes('lightningWebComponent1')).toBe(true);
 
     expect(filteredTreeViewItems.includes('lightningWebComponent1.html')).toBe(true);
@@ -528,7 +804,7 @@ describe('Templates', async () => {
     ].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('lightningWebComponent1.js') as TextEditor;
+    const textEditor = (await editorView.openEditor('lightningWebComponent1.js')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -538,11 +814,19 @@ describe('Templates', async () => {
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  lightningWebComponent1  LightningComponentBundle');
   });
@@ -552,7 +836,11 @@ describe('Templates', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Visualforce Component".
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Visualforce Component', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Visualforce Component',
+      1
+    );
 
     // Set the name of the new component to VisualforceCmp1.
     await inputBox.setText('VisualforceCmp1');
@@ -562,20 +850,44 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Visualforce Component successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Visualforce Component successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Visualforce Component', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Visualforce Component',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
-    const componentPath = path.join('force-app', 'main', 'default', 'components', 'VisualforceCmp1.component');
+    const componentPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'components',
+      'VisualforceCmp1.component'
+    );
     expect(outputPanelText).toContain(`create ${componentPath}`);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'components', 'VisualforceCmp1.component-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'components',
+      'VisualforceCmp1.component-meta.xml'
+    );
     expect(outputPanelText).toContain(`create ${metadataPath}`);
 
     // Get the matching (visible) items within the tree which contains "AuraInterface1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'VisualforceCmp1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'VisualforceCmp1'
+    );
     expect(filteredTreeViewItems.includes('VisualforceCmp1.component')).toBe(true);
     expect(filteredTreeViewItems.includes('VisualforceCmp1.component-meta.xml')).toBe(true);
   });
@@ -592,7 +904,7 @@ describe('Templates', async () => {
     ].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('VisualforceCmp1.component') as TextEditor;
+    const textEditor = (await editorView.openEditor('VisualforceCmp1.component')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -603,18 +915,38 @@ describe('Templates', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  VisualforceCmp1  ApexComponent');
 
-    const componentPath = path.join('force-app', 'main', 'default', 'components', 'VisualforceCmp1.component');
+    const componentPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'components',
+      'VisualforceCmp1.component'
+    );
     expect(outputPanelText).toContain(componentPath);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'components', 'VisualforceCmp1.component-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'components',
+      'VisualforceCmp1.component-meta.xml'
+    );
     expect(outputPanelText).toContain(metadataPath);
   });
 
@@ -623,7 +955,11 @@ describe('Templates', async () => {
     // Clear the output panel, then use the Command palette to run, "SFDX: Create Visualforce Page".
     const workbench = await browser.getWorkbench();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Visualforce Page', 1);
+    const inputBox = await utilities.runCommandFromCommandPrompt(
+      workbench,
+      'SFDX: Create Visualforce Page',
+      1
+    );
 
     // Set the name of the new page to VisualforcePage1.
     await inputBox.setText('VisualforcePage1');
@@ -633,20 +969,44 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Create Visualforce Page successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Create Visualforce Page successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', 'Finished SFDX: Create Visualforce Page', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      'Finished SFDX: Create Visualforce Page',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
 
-    const visualforcePagePath = path.join('force-app', 'main', 'default', 'pages', 'VisualforcePage1.page');
+    const visualforcePagePath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'pages',
+      'VisualforcePage1.page'
+    );
     expect(outputPanelText).toContain(`create ${visualforcePagePath}`);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'pages', 'VisualforcePage1.page-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'pages',
+      'VisualforcePage1.page-meta.xml'
+    );
     expect(outputPanelText).toContain(`create ${metadataPath}`);
 
     // Get the matching (visible) items within the tree which contains "AuraInterface1".
-    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(workbench, projectName, 'VisualforcePage1');
+    const filteredTreeViewItems = await utilities.getFilteredVisibleTreeViewItemLabels(
+      workbench,
+      projectName,
+      'VisualforcePage1'
+    );
     expect(filteredTreeViewItems.includes('VisualforcePage1.page')).toBe(true);
     expect(filteredTreeViewItems.includes('VisualforcePage1.page-meta.xml')).toBe(true);
   });
@@ -663,7 +1023,7 @@ describe('Templates', async () => {
     ].join('\n');
     const workbench = await browser.getWorkbench();
     const editorView = await workbench.getEditorView();
-    const textEditor = await editorView.openEditor('VisualforcePage1.page') as TextEditor;
+    const textEditor = (await editorView.openEditor('VisualforcePage1.page')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toEqual(expectedText);
   });
@@ -674,18 +1034,38 @@ describe('Templates', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(workbench, 'SFDX: Push Source to Default Org successfully ran', 10);
+    const successNotificationWasFound = await utilities.attemptToFindNotification(
+      workbench,
+      'SFDX: Push Source to Default Org successfully ran',
+      10
+    );
     expect(successNotificationWasFound).toBe(true);
 
     // Check the output.
-    const outputPanelText = await utilities.attemptToFindOutputPanelText('Salesforce CLI', '=== Pushed Source', 10);
+    const outputPanelText = await utilities.attemptToFindOutputPanelText(
+      'Salesforce CLI',
+      '=== Pushed Source',
+      10
+    );
     expect(outputPanelText).not.toBeUndefined();
     expect(outputPanelText).toContain('Created  VisualforcePage1  ApexPage');
 
-    const visualforcePagePath = path.join('force-app', 'main', 'default', 'pages', 'VisualforcePage1.page');
+    const visualforcePagePath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'pages',
+      'VisualforcePage1.page'
+    );
     expect(outputPanelText).toContain(visualforcePagePath);
 
-    const metadataPath = path.join('force-app', 'main', 'default', 'pages', 'VisualforcePage1.page-meta.xml');
+    const metadataPath = path.join(
+      'force-app',
+      'main',
+      'default',
+      'pages',
+      'VisualforcePage1.page-meta.xml'
+    );
     expect(outputPanelText).toContain(metadataPath);
   });
 

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -93,12 +93,12 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexClass1.cls')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
+    const textGeneratedFromTemplate = await textEditor.getText();
     await utilities.log('textGeneratedFromTemplate:');
     await utilities.log(textGeneratedFromTemplate);
     await utilities.log('expectedText:');
     await utilities.log(expectedText);
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Apex Trigger
@@ -173,8 +173,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Aura App
@@ -291,8 +291,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Aura Component
@@ -352,8 +352,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraComponent1.cmp')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Aura Event
@@ -412,8 +412,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraEvent1.evt')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Aura Interface
@@ -490,8 +490,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraInterface1.intf')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Lightning Web Component
@@ -553,8 +553,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lightningWebComponent1.js')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Visualforce Component
@@ -631,8 +631,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforceCmp1.component')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Visualforce Page
@@ -709,8 +709,8 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforcePage1.page')) as TextEditor;
-    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
-    expect(textGeneratedFromTemplate).toEqual(expectedText);
+    const textGeneratedFromTemplate = await textEditor.getText();
+    expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 
   // Tear down

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -287,7 +287,7 @@ describe('Templates', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
-    const textGeneratedFromTemplate = await textEditor.getText();
+    const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd();
     expect(textGeneratedFromTemplate).toBe(expectedText);
   });
 


### PR DESCRIPTION
Makes sure templates.e2e.ts successfully passes on remote GHA

How to test:
Go to the [End to End Tests Workflow](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/e2e.yml) in salesforcedx-vscode repo
Paste the PR's branch (cristi/push-pull-on-remote) in the second field of the Run workflow dropdown (Set the branch to use for automation tests)
Choose templates.e2e.ts test from the dropdown to select the test to run.
AC:
Test suite should pass.

Successful runs:
- 
-
-
-
@W-13744004@