### PR TITLE
auraLsp.test.ts runs successfully on remote

### DIFF
--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -8,6 +8,8 @@ import { step } from 'mocha-steps';
 import { TextEditor } from 'wdio-vscode-service';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
+import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
+import { Key } from 'webdriverio';
 
 describe('Aura LSP', async () => {
   let testSetup: TestSetup;
@@ -43,7 +45,22 @@ describe('Aura LSP', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('aura1.cmp')) as TextEditor;
-    await textEditor.moveCursor(8, 10);
+
+    // Select text
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys(["!v.sim"]);
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowRight']);
+    await utilities.pause(1);
+
+    // await textEditor.moveCursor(8, 20);
+    // for (let x = 0; x < 8; x++) {
+    //   await browser.keys(['ArrowDown']);
+    // }
+    // for (let y = 0; y < 10; y++) {
+    //   await browser.keys(['ArrowRight']);
+    // }
 
     // Go to definition through F12
     await browser.keys(['F12']);

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -9,7 +9,6 @@ import { TextEditor } from 'wdio-vscode-service';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
 import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
-import { Key } from 'webdriverio';
 
 describe('Aura LSP', async () => {
   let testSetup: TestSetup;
@@ -46,7 +45,7 @@ describe('Aura LSP', async () => {
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('aura1.cmp')) as TextEditor;
 
-    // Select text
+    // Move cursor to the middle of "simpleNewContact"
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
     await browser.keys(["!v.sim"]);
@@ -54,19 +53,11 @@ describe('Aura LSP', async () => {
     await browser.keys(['ArrowRight']);
     await utilities.pause(1);
 
-    // await textEditor.moveCursor(8, 20);
-    // for (let x = 0; x < 8; x++) {
-    //   await browser.keys(['ArrowDown']);
-    // }
-    // for (let y = 0; y < 10; y++) {
-    //   await browser.keys(['ArrowRight']);
-    // }
-
     // Go to definition through F12
     await browser.keys(['F12']);
     await utilities.pause(1);
 
-    //Verify 'Go to definition'
+    // Verify 'Go to definition'
     const definition = await textEditor.getCoordinates();
     expect(definition[0]).toBe(3);
     expect(definition[1]).toBe(27);


### PR DESCRIPTION
### How to test:
(1) Go to the [End to End Tests Workflow](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/e2e.yml) in salesforcedx-vscode repo
(2) Paste the PR's branch (daphne/auraLSP-on-remote) in the second field of the Run workflow dropdown (Set the branch to use for automation tests)
(3) Choose auraLsp.e2e.ts test from the dropdown to select the test to run.

AC:
Test suite should pass.

### Key change made:
Replaced the call to textEditor.moveCursor() with a mechanism that uses browser.keys.  To get the cursor to the desired position in the middle of the word, the code uses browser.keys to search for and highlight a portion of the word using CMD + f and then presses 'Escape' and 'ArrowRight' to move the cursor directly to the right of the highlighted portion, which is to support the Go to Definition using F12.

### Successful runs:
• [306](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5863317316)
• [307](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5863320334)
• [308](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5863321999)

@W-13743988@