### PR TITLE
debugApexTests.test.ts runs successfully on remote

### DIFF
--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { step } from 'mocha-steps';
-import { SideBarView, TextEditor, TreeItem } from 'wdio-vscode-service';
+import { TextEditor, TreeItem } from 'wdio-vscode-service';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
 

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -122,6 +122,32 @@ describe('Debug Apex Tests', async () => {
     const apexTestsSection = await sidebarView.getSection('APEX TESTS');
     expect(apexTestsSection.elem).toBePresent();
 
+    let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+
+    // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
+    for (let x = 0; x < 3; x++) {
+      if (apexTestsItems.length === 1) {
+        await apexTestsSection.elem.click();
+        const refreshAction = await apexTestsSection.getAction('Refresh Tests');
+        await refreshAction!.elem.click();
+        utilities.pause(10);
+        apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+      }
+      else if (apexTestsItems.length === 6) {
+        break;
+      }
+      else {
+        // do nothing
+      }
+    }
+
+    // Make sure all the tests are present in the sidebar
+    expect(apexTestsItems.length).toBe(4);
+    expect(await apexTestsSection.findItem('ExampleApexClass1Test')).toBeTruthy();
+    expect(await apexTestsSection.findItem('ExampleApexClass2Test')).toBeTruthy();
+    expect(await apexTestsItems[0].getLabel()).toBe('ExampleApexClass1Test');
+    expect(await apexTestsItems[2].getLabel()).toBe('ExampleApexClass2Test');
+
     // Click the debug tests button that is shown to the right when you hover a test class name on the Test sidebar
     await browser.keys(['Escape']);
     await apexTestsSection.elem.click();

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -13,7 +13,7 @@ describe('Debug Apex Tests', async () => {
   let testSetup: TestSetup;
 
   step('Set up the testing environment', async () => {
-    testSetup = new TestSetup('DebugApexTests', true);
+    testSetup = new TestSetup('DebugApexTests', false);
     await testSetup.setUp();
 
     // Create Apex class 1 and test
@@ -112,15 +112,17 @@ describe('Debug Apex Tests', async () => {
   step('Debug all Apex Methods on a Class via the Test Sidebar', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     utilities.log('1');
-    const activityBar = workbench.getActivityBar();
-    utilities.log('1.5');
-    const testingView = await activityBar.getViewControl('Testing');
+    // const activityBar = workbench.getActivityBar();
+    // utilities.log('1.5');
+    // const testingView = await activityBar.getViewControl('Testing');
     // const testingView = await workbench.getActivityBar().getViewControl('Testing');
+    // Run SFDX: Run Apex tests.
+    await utilities.runCommandFromCommandPrompt(workbench, 'Testing: Focus on Apex Tests View', 1);
     utilities.log('2');
 
     // Open the Test Sidebar
-    const testingSideBarView = await testingView?.openView();
-    expect(testingSideBarView).toBeInstanceOf(SideBarView);
+    // const testingSideBarView = await testingView?.openView();
+    // expect(testingSideBarView).toBeInstanceOf(SideBarView);
     utilities.log('3');
 
     const sidebar = workbench.getSideBar();
@@ -144,7 +146,7 @@ describe('Debug Apex Tests', async () => {
         utilities.pause(10);
         apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
       }
-      else if (apexTestsItems.length === 6) {
+      else if (apexTestsItems.length === 4) {
         break;
       }
       else {

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -130,6 +130,7 @@ describe('Debug Apex Tests', async () => {
 
     let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
     utilities.log('7');
+    await browser.keys(['Escape']);
 
     // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
     for (let x = 0; x < 3; x++) {
@@ -158,7 +159,6 @@ describe('Debug Apex Tests', async () => {
     utilities.log('9');
 
     // Click the debug tests button that is shown to the right when you hover a test class name on the Test sidebar
-    await browser.keys(['Escape']);
     utilities.log('10');
     await apexTestsSection.elem.click();
     utilities.log('11');

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -25,27 +25,30 @@ describe('Debug Apex Tests', async () => {
     await utilities.pause(1);
 
     // Push source to org
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts',
       1
     );
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+
+    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Override Conflicts successfully ran".
+    const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successPushNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran'
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
 
   step('Debug All Tests via Apex Class', async () => {
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
+
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleApexClass1Test.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
+
     const editorView = workbench.getEditorView();
 
     // Open an existing apex test
@@ -57,16 +60,11 @@ describe('Debug Apex Tests', async () => {
     const debugAllTestsOption = await codeLensElem?.$('=Debug All Tests');
     await debugAllTestsOption!.click();
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    // Look for the success notification that appears which says, "Debug Test(s) successfully ran".
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running Debug Test(s)',
+      'Debug Test(s) successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'Debug Test(s) successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -78,7 +76,13 @@ describe('Debug Apex Tests', async () => {
   });
 
   step('Debug Single Test via Apex Class', async () => {
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
+
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleApexClass2Test.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
+
     const editorView = workbench.getEditorView();
 
     // Open an existing apex test
@@ -90,16 +94,11 @@ describe('Debug Apex Tests', async () => {
     const debugTestOption = await codeLensElem?.$('=Debug Test');
     await debugTestOption!.click();
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    // Look for the success notification that appears which says, "Debug Test(s) successfully ran".
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running Debug Test(s)',
+      'Debug Test(s) successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'Debug Test(s) successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -111,7 +110,7 @@ describe('Debug Apex Tests', async () => {
   });
 
   step('Debug all Apex Methods on a Class via the Test Sidebar', async () => {
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const testingView = await workbench.getActivityBar().getViewControl('Testing');
 
     // Open the Test Sidebar
@@ -130,16 +129,11 @@ describe('Debug Apex Tests', async () => {
     await runTestsAction!.elem.click();
     await utilities.pause(1);
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    // Look for the success notification that appears which says, "Debug Test(s) successfully ran".
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running Debug Test(s)',
+      'Debug Test(s) successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'Debug Test(s) successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -151,7 +145,7 @@ describe('Debug Apex Tests', async () => {
   });
 
   step('Debug a Single Apex Test Method via the Test Sidebar', async () => {
-    const workbench = await browser.getWorkbench();
+    const workbench = await (await browser.getWorkbench()).wait();
     const testingView = await workbench.getActivityBar().getViewControl('Testing');
 
     // Open the Test Sidebar
@@ -170,16 +164,11 @@ describe('Debug Apex Tests', async () => {
     await runTestAction!.elem.click();
     await utilities.pause(1);
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    // Look for the success notification that appears which says, "Debug Test(s) successfully ran".
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running Debug Test(s)',
+      'Debug Test(s) successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'Debug Test(s) successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -123,6 +123,8 @@ describe('Debug Apex Tests', async () => {
     expect(apexTestsSection.elem).toBePresent();
 
     // Click the debug tests button that is shown to the right when you hover a test class name on the Test sidebar
+    await browser.keys(['Escape']);
+    await apexTestsSection.elem.click();
     const apexTestItem = (await apexTestsSection.findItem('ExampleApexClass1Test')) as TreeItem;
     await apexTestItem.select();
     const runTestsAction = await apexTestItem.getActionButton('Debug Tests');
@@ -158,6 +160,8 @@ describe('Debug Apex Tests', async () => {
     expect(apexTestsSection.elem).toBePresent();
 
     // Hover a test name under one of the test class sections and click the debug button that is shown to the right of the test name on the Test sidebar
+    await browser.keys(['Escape']);
+    await apexTestsSection.elem.click();
     const apexTestItem = (await apexTestsSection.findItem('validateSayHello')) as TreeItem;
     await apexTestItem.select();
     const runTestAction = await apexTestItem.getActionButton('Debug Single Test');

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -13,7 +13,7 @@ describe('Debug Apex Tests', async () => {
   let testSetup: TestSetup;
 
   step('Set up the testing environment', async () => {
-    testSetup = new TestSetup('DebugApexTests', false);
+    testSetup = new TestSetup('DebugApexTests', true);
     await testSetup.setUp();
 
     // Create Apex class 1 and test
@@ -112,7 +112,10 @@ describe('Debug Apex Tests', async () => {
   step('Debug all Apex Methods on a Class via the Test Sidebar', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     utilities.log('1');
-    const testingView = await workbench.getActivityBar().getViewControl('Testing');
+    const activityBar = workbench.getActivityBar();
+    utilities.log('1.5');
+    const testingView = await activityBar.getViewControl('Testing');
+    // const testingView = await workbench.getActivityBar().getViewControl('Testing');
     utilities.log('2');
 
     // Open the Test Sidebar

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -111,18 +111,25 @@ describe('Debug Apex Tests', async () => {
 
   step('Debug all Apex Methods on a Class via the Test Sidebar', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
+    utilities.log('1');
     const testingView = await workbench.getActivityBar().getViewControl('Testing');
+    utilities.log('2');
 
     // Open the Test Sidebar
     const testingSideBarView = await testingView?.openView();
     expect(testingSideBarView).toBeInstanceOf(SideBarView);
+    utilities.log('3');
 
     const sidebar = workbench.getSideBar();
+    utilities.log('4');
     const sidebarView = sidebar.getContent();
+    utilities.log('5');
     const apexTestsSection = await sidebarView.getSection('APEX TESTS');
     expect(apexTestsSection.elem).toBePresent();
+    utilities.log('6');
 
     let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+    utilities.log('7');
 
     // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
     for (let x = 0; x < 3; x++) {
@@ -140,6 +147,7 @@ describe('Debug Apex Tests', async () => {
         // do nothing
       }
     }
+    utilities.log('8');
 
     // Make sure all the tests are present in the sidebar
     expect(apexTestsItems.length).toBe(4);
@@ -147,14 +155,19 @@ describe('Debug Apex Tests', async () => {
     expect(await apexTestsSection.findItem('ExampleApexClass2Test')).toBeTruthy();
     expect(await apexTestsItems[0].getLabel()).toBe('ExampleApexClass1Test');
     expect(await apexTestsItems[2].getLabel()).toBe('ExampleApexClass2Test');
+    utilities.log('9');
 
     // Click the debug tests button that is shown to the right when you hover a test class name on the Test sidebar
     await browser.keys(['Escape']);
+    utilities.log('10');
     await apexTestsSection.elem.click();
+    utilities.log('11');
     const apexTestItem = (await apexTestsSection.findItem('ExampleApexClass1Test')) as TreeItem;
     await apexTestItem.select();
+    utilities.log('12');
     const runTestsAction = await apexTestItem.getActionButton('Debug Tests');
     await runTestsAction!.elem.click();
+    utilities.log('13');
     await utilities.pause(1);
 
     // Look for the success notification that appears which says, "Debug Test(s) successfully ran".
@@ -164,11 +177,14 @@ describe('Debug Apex Tests', async () => {
       utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
+    utilities.log('14');
 
     // Continue with the debug session
     await browser.keys(['F5']);
+    utilities.log('15');
     await utilities.pause(1);
     await browser.keys(['F5']);
+    utilities.log('16');
     await utilities.pause(1);
   });
 

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -113,6 +113,7 @@ describe('Debug Apex Tests', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'Testing: Focus on Apex Tests View', 1);
 
+    // Open the Test Sidebar
     const sidebar = workbench.getSideBar();
     const sidebarView = sidebar.getContent();
     const apexTestsSection = await sidebarView.getSection('APEX TESTS');
@@ -170,12 +171,9 @@ describe('Debug Apex Tests', async () => {
 
   step('Debug a Single Apex Test Method via the Test Sidebar', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
-    const testingView = await workbench.getActivityBar().getViewControl('Testing');
+    await utilities.runCommandFromCommandPrompt(workbench, 'Testing: Focus on Apex Tests View', 1);
 
     // Open the Test Sidebar
-    const testingSideBarView = await testingView?.openView();
-    expect(testingSideBarView).toBeInstanceOf(SideBarView);
-
     const sidebar = workbench.getSideBar();
     const sidebarView = sidebar.getContent();
     const apexTestsSection = await sidebarView.getSection('APEX TESTS');

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -119,25 +119,7 @@ describe('Debug Apex Tests', async () => {
     const apexTestsSection = await sidebarView.getSection('APEX TESTS');
     expect(apexTestsSection.elem).toBePresent();
 
-    let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
-    await browser.keys(['Escape']);
-
-    // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
-    for (let x = 0; x < 3; x++) {
-      if (apexTestsItems.length === 1) {
-        await apexTestsSection.elem.click();
-        const refreshAction = await apexTestsSection.getAction('Refresh Tests');
-        await refreshAction!.elem.click();
-        utilities.pause(10);
-        apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
-      }
-      else if (apexTestsItems.length === 4) {
-        break;
-      }
-      else {
-        // do nothing
-      }
-    }
+    let apexTestsItems = await utilities.retrieveAllApexTestItemsFromSidebar(4, apexTestsSection);
 
     // Make sure all the tests are present in the sidebar
     expect(apexTestsItems.length).toBe(4);

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -111,30 +111,14 @@ describe('Debug Apex Tests', async () => {
 
   step('Debug all Apex Methods on a Class via the Test Sidebar', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
-    utilities.log('1');
-    // const activityBar = workbench.getActivityBar();
-    // utilities.log('1.5');
-    // const testingView = await activityBar.getViewControl('Testing');
-    // const testingView = await workbench.getActivityBar().getViewControl('Testing');
-    // Run SFDX: Run Apex tests.
     await utilities.runCommandFromCommandPrompt(workbench, 'Testing: Focus on Apex Tests View', 1);
-    utilities.log('2');
-
-    // Open the Test Sidebar
-    // const testingSideBarView = await testingView?.openView();
-    // expect(testingSideBarView).toBeInstanceOf(SideBarView);
-    utilities.log('3');
 
     const sidebar = workbench.getSideBar();
-    utilities.log('4');
     const sidebarView = sidebar.getContent();
-    utilities.log('5');
     const apexTestsSection = await sidebarView.getSection('APEX TESTS');
     expect(apexTestsSection.elem).toBePresent();
-    utilities.log('6');
 
     let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
-    utilities.log('7');
     await browser.keys(['Escape']);
 
     // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
@@ -153,7 +137,6 @@ describe('Debug Apex Tests', async () => {
         // do nothing
       }
     }
-    utilities.log('8');
 
     // Make sure all the tests are present in the sidebar
     expect(apexTestsItems.length).toBe(4);
@@ -161,18 +144,13 @@ describe('Debug Apex Tests', async () => {
     expect(await apexTestsSection.findItem('ExampleApexClass2Test')).toBeTruthy();
     expect(await apexTestsItems[0].getLabel()).toBe('ExampleApexClass1Test');
     expect(await apexTestsItems[2].getLabel()).toBe('ExampleApexClass2Test');
-    utilities.log('9');
 
     // Click the debug tests button that is shown to the right when you hover a test class name on the Test sidebar
-    utilities.log('10');
     await apexTestsSection.elem.click();
-    utilities.log('11');
     const apexTestItem = (await apexTestsSection.findItem('ExampleApexClass1Test')) as TreeItem;
     await apexTestItem.select();
-    utilities.log('12');
     const runTestsAction = await apexTestItem.getActionButton('Debug Tests');
     await runTestsAction!.elem.click();
-    utilities.log('13');
     await utilities.pause(1);
 
     // Look for the success notification that appears which says, "Debug Test(s) successfully ran".
@@ -182,14 +160,11 @@ describe('Debug Apex Tests', async () => {
       utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
-    utilities.log('14');
 
     // Continue with the debug session
     await browser.keys(['F5']);
-    utilities.log('15');
     await utilities.pause(1);
     await browser.keys(['F5']);
-    utilities.log('16');
     await utilities.pause(1);
   });
 

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TextEditor, TreeItem, ViewSection } from 'wdio-vscode-service';
+import { TextEditor } from 'wdio-vscode-service';
 import { runCommandFromCommandPrompt } from './commandPrompt';
 import { pause } from './miscellaneous';
 
@@ -143,26 +143,4 @@ export async function createApexController(): Promise<void> {
     `}`
   ].join('\n');
   await createApexClass('MyController', classText);
-}
-
-export async function retrieveAllApexTestItemsFromSidebar(expectedNumTests: number, apexTestsSection: ViewSection): Promise<TreeItem[]> {
-
-  let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
-  await browser.keys(['Escape']);
-
-  // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
-  for (let x = 0; x < 3; x++) {
-    if (apexTestsItems.length === 1) {
-      await apexTestsSection.elem.click();
-      const refreshAction = await apexTestsSection.getAction('Refresh Tests');
-      await refreshAction!.elem.click();
-      pause(10);
-      apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
-    }
-    else if (apexTestsItems.length === expectedNumTests) {
-      break;
-    }
-  }
-
-  return apexTestsItems;
 }

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TextEditor } from 'wdio-vscode-service';
+import { TextEditor, TreeItem, ViewSection } from 'wdio-vscode-service';
 import { runCommandFromCommandPrompt } from './commandPrompt';
 import { pause } from './miscellaneous';
 
@@ -143,4 +143,26 @@ export async function createApexController(): Promise<void> {
     `}`
   ].join('\n');
   await createApexClass('MyController', classText);
+}
+
+export async function retrieveAllApexTestItemsFromSidebar(expectedNumTests: number, apexTestsSection: ViewSection): Promise<TreeItem[]> {
+
+  let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+  await browser.keys(['Escape']);
+
+  // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
+  for (let x = 0; x < 3; x++) {
+    if (apexTestsItems.length === 1) {
+      await apexTestsSection.elem.click();
+      const refreshAction = await apexTestsSection.getAction('Refresh Tests');
+      await refreshAction!.elem.click();
+      pause(10);
+      apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+    }
+    else if (apexTestsItems.length === expectedNumTests) {
+      break;
+    }
+  }
+
+  return apexTestsItems;
 }

--- a/test/utilities/sideBar.ts
+++ b/test/utilities/sideBar.ts
@@ -9,8 +9,10 @@ import {
   DefaultTreeItem,
   TreeItem,
   ViewItem,
-  Workbench
+  Workbench,
+  ViewSection
 } from 'wdio-vscode-service';
+import { pause } from './miscellaneous';
 
 export async function getFilteredVisibleTreeViewItems(workbench: Workbench, projectName: string, searchString: string): Promise<DefaultTreeItem[]> {
   const sidebar = workbench.getSideBar();
@@ -98,4 +100,26 @@ export async function getVisibleItems(treeItem: TreeItem, locator: string): Prom
   const rows = await treeItem.parent.$$(locator);
 
   return rows;
+}
+
+export async function retrieveAllApexTestItemsFromSidebar(expectedNumTests: number, apexTestsSection: ViewSection): Promise<TreeItem[]> {
+
+  let apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+  await browser.keys(['Escape']);
+
+  // If the Apex tests did not show up, click the refresh button on the top right corner of the Test sidebar
+  for (let x = 0; x < 3; x++) {
+    if (apexTestsItems.length === 1) {
+      await apexTestsSection.elem.click();
+      const refreshAction = await apexTestsSection.getAction('Refresh Tests');
+      await refreshAction!.elem.click();
+      pause(10);
+      apexTestsItems = (await apexTestsSection.getVisibleItems()) as TreeItem[];
+    }
+    else if (apexTestsItems.length === expectedNumTests) {
+      break;
+    }
+  }
+
+  return apexTestsItems;
 }


### PR DESCRIPTION
### How to test:
(1) Go to the [End to End Tests Workflow](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/e2e.yml) in salesforcedx-vscode repo
(2) Paste the PR's branch (daphne/debugApexTests-on-remote) in the second field of the Run workflow dropdown (Set the branch to use for automation tests)
(3) Choose debugApexTests.e2e.ts test from the dropdown to select the test to run.

AC:
Test suite should pass.

### Key changes made:

(1) Added logic to trigger refreshment of the APEX TESTS section of the sidebar if tests do not show up.

(2) Used notificationIsPresentWithTimeout() instead of notificationIsPresent().  As a result of the change, removed all calls to waitForNotificationToGoAway().

(3) Uncovered the 'Debug' button that was previously covered by the command palette due to small VSCode window size in Remote.

(4) Used the 'Testing: Focus on Apex Tests View' prompt in the command palette to open the Testing view instead of using the sidebar.

### Successful runs:
• [338](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5895691735)
• [339](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5895695565)
• [340](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5895698456)

@W-13743990@