### PR TITLE
Visualforce E2E Test - zoom out to make Visualforce extension visible in running extensions

### DIFF
--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -65,6 +65,10 @@ describe('Visualforce LSP', async () => {
     // Using the Command palette, run Developer: Show Running Extensions
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.showRunningExtensions(workbench);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
 
     // Verify Visualforce extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(

--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -65,10 +65,10 @@ describe('Visualforce LSP', async () => {
     // Using the Command palette, run Developer: Show Running Extensions
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.showRunningExtensions(workbench);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 5);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
 
     // Verify Visualforce extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(


### PR DESCRIPTION
Previously, the Visualforce E2E test sometimes failed in the "Verify Extension is Running" step, which checks that the Visualforce extension is present in "Developer: Show Running Extensions".  The Visualforce extension is in fact started up but hidden at the bottom of the list and only accessible using the scroll bar.  To fix the problem, I added four "View: Zoom Out" lines before checking for the Visualforce extension in the list of running extensions so that all the running extensions are visible during the check.