### PR TITLE
Improve consistency of notification checking in E2E tests

### DIFF
--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -33,7 +33,7 @@ describe('Apex Replay Debugger', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -72,7 +72,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -112,7 +112,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Execute Anonymous Apex successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -145,7 +145,7 @@ describe('Apex Replay Debugger', async () => {
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Getting Apex debug logs',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
 
     // Select a log file
@@ -157,7 +157,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Get Apex Debug Logs successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -247,7 +247,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Execute Anonymous Apex successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -279,7 +279,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn Off Apex Debug Log for Replay Debugger successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -33,7 +33,7 @@ describe('Apex Replay Debugger', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -72,7 +72,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -112,7 +112,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Execute Anonymous Apex successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -145,7 +145,7 @@ describe('Apex Replay Debugger', async () => {
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Getting Apex debug logs',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
 
     // Select a log file
@@ -157,7 +157,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Get Apex Debug Logs successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -247,7 +247,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Execute Anonymous Apex successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -279,7 +279,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn Off Apex Debug Log for Replay Debugger successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -29,15 +29,11 @@ describe('Apex Replay Debugger', async () => {
       'SFDX: Push Source to Default Org and Override Conflicts',
       1
     );
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+
+    const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successPushNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran'
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -72,17 +68,11 @@ describe('Apex Replay Debugger', async () => {
       10
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Turn On Apex Debug Log for Replay Debugger',
-      utilities.FIVE_MINUTES
-    );
-
     // Look for the success notification that appears which says, "SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran".
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran'
+      'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -119,16 +109,10 @@ describe('Apex Replay Debugger', async () => {
       1
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running Execute Anonymous Apex',
+      'Execute Anonymous Apex successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'Execute Anonymous Apex successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -170,16 +154,10 @@ describe('Apex Replay Debugger', async () => {
     expect(quickPicks.length).toBeGreaterThanOrEqual(1);
     await prompt.selectQuickPick('User User - Api');
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Get Apex Debug Logs',
+      'SFDX: Get Apex Debug Logs successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Get Apex Debug Logs successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -266,15 +244,10 @@ describe('Apex Replay Debugger', async () => {
       10
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running Execute Anonymous Apex',
+      'Execute Anonymous Apex successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'Execute Anonymous Apex successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -302,17 +275,11 @@ describe('Apex Replay Debugger', async () => {
       1
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Turn Off Apex Debug Log for Replay Debugger',
-      utilities.FIVE_MINUTES
-    );
-
     // Look for the success notification that appears which says, "SFDX: Turn Off Apex Debug Log for Replay Debugger successfully ran".
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Turn Off Apex Debug Log for Replay Debugger successfully ran'
+      'SFDX: Turn Off Apex Debug Log for Replay Debugger successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -33,7 +33,7 @@ describe('Apex Replay Debugger', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -72,7 +72,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -112,7 +112,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Execute Anonymous Apex successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -145,7 +145,7 @@ describe('Apex Replay Debugger', async () => {
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Getting Apex debug logs',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
 
     // Select a log file
@@ -157,7 +157,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Get Apex Debug Logs successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -247,7 +247,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Execute Anonymous Apex successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -279,7 +279,7 @@ describe('Apex Replay Debugger', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn Off Apex Debug Log for Replay Debugger successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -103,9 +103,10 @@ describe('Authentication', async () => {
     await utilities.pause(5);
 
     // Look for the notification that appears which says, "SFDX: Set a Default Org successfully ran".
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Set a Default Org successfully ran'
+      'SFDX: Set a Default Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -156,20 +157,16 @@ describe('Authentication', async () => {
     // Press Enter/Return.
     await prompt.confirm();
 
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Create a Default Scratch Org...',
+      'SFDX: Create a Default Scratch Org... successfully ran',
       utilities.FIVE_MINUTES
     );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Create a Default Scratch Org... successfully ran'
-    );
     if (successNotificationWasFound !== true) {
-      const failureNotificationWasFound = await utilities.notificationIsPresent(
+      const failureNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
         workbench,
-        'SFDX: Create a Default Scratch Org... failed to run'
+        'SFDX: Create a Default Scratch Org... failed to run',
+        utilities.FIVE_MINUTES
       );
       if (failureNotificationWasFound === true) {
         if (
@@ -236,9 +233,10 @@ describe('Authentication', async () => {
 
     await utilities.pause(3);
 
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Set a Default Org successfully ran'
+      'SFDX: Set a Default Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -106,7 +106,7 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -160,13 +160,13 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create a Default Scratch Org... successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     if (successNotificationWasFound !== true) {
       const failureNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
         workbench,
         'SFDX: Create a Default Scratch Org... failed to run',
-        utilities.FIVE_MINUTES
+        utilities.TEN_MINUTES
       );
       if (failureNotificationWasFound === true) {
         if (
@@ -236,7 +236,7 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -106,7 +106,7 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -160,13 +160,13 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create a Default Scratch Org... successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     if (successNotificationWasFound !== true) {
       const failureNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
         workbench,
         'SFDX: Create a Default Scratch Org... failed to run',
-        utilities.TEN_MINUTES
+        utilities.FIFTEEN_MINUTES
       );
       if (failureNotificationWasFound === true) {
         if (
@@ -236,7 +236,7 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -106,7 +106,7 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -160,13 +160,13 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create a Default Scratch Org... successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     if (successNotificationWasFound !== true) {
       const failureNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
         workbench,
         'SFDX: Create a Default Scratch Org... failed to run',
-        utilities.FIFTEEN_MINUTES
+        utilities.TEN_MINUTES
       );
       if (failureNotificationWasFound === true) {
         if (
@@ -236,7 +236,7 @@ describe('Authentication', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -36,7 +36,7 @@ describe('Debug Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -77,7 +77,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -111,7 +111,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -153,7 +153,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -187,7 +187,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -36,7 +36,7 @@ describe('Debug Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -77,7 +77,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -111,7 +111,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -153,7 +153,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -187,7 +187,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -36,7 +36,7 @@ describe('Debug Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -77,7 +77,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -111,7 +111,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -153,7 +153,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -187,7 +187,7 @@ describe('Debug Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'Debug Test(s) successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -100,7 +100,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -130,7 +130,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -168,7 +168,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -202,7 +202,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -243,7 +243,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
     const textAfterRetrieve = await textEditor.getText();
@@ -317,7 +317,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -379,7 +379,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -409,7 +409,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -447,7 +447,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -100,7 +100,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -130,7 +130,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -168,7 +168,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -202,7 +202,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -243,7 +243,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
     const textAfterRetrieve = await textEditor.getText();
@@ -317,7 +317,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -379,7 +379,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -409,7 +409,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -447,7 +447,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -95,16 +95,12 @@ describe('Deploy and Retrieve', async () => {
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Deploy Source to Org',
-      utilities.FIVE_MINUTES
-    );
+
     // At this point there should be no conflicts since this is a new class.
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Deploy Source to Org successfully ran'
+      'SFDX: Deploy Source to Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -130,15 +126,11 @@ describe('Deploy and Retrieve', async () => {
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Deploy Source to Org',
+      'SFDX: Deploy Source to Org successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Deploy Source to Org successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -173,15 +165,10 @@ describe('Deploy and Retrieve', async () => {
     // Deploy running SFDX: Deploy This Source to Org
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Deploy Source to Org',
+      'SFDX: Deploy Source to Org successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Deploy Source to Org successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -211,16 +198,11 @@ describe('Deploy and Retrieve', async () => {
       'SFDX: Retrieve This Source from Org',
       5
     );
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Retrieve Source from Org',
-      utilities.FIVE_MINUTES
-    );
 
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Retrieve Source from Org successfully ran'
+      'SFDX: Retrieve Source from Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -257,16 +239,11 @@ describe('Deploy and Retrieve', async () => {
       5
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Retrieve Source from Org',
-      utilities.FIVE_MINUTES
-    );
     await utilities.pause(3);
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Retrieve Source from Org successfully ran'
+      'SFDX: Retrieve Source from Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
     const textAfterRetrieve = await textEditor.getText();
@@ -335,17 +312,12 @@ describe('Deploy and Retrieve', async () => {
     await textEditor.setTextAtLine(2, `\t// let's trigger deploy`);
     await textEditor.save();
     await utilities.pause(5);
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Deploy Source to Org',
-      utilities.FIVE_MINUTES
-    );
-    await utilities.pause(5);
+
     // At this point there should be no conflicts since this is a new class.
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Deploy Source to Org successfully ran'
+      'SFDX: Deploy Source to Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -402,16 +374,12 @@ describe('Deploy and Retrieve', async () => {
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Deploy Source to Org',
-      utilities.FIVE_MINUTES
-    );
+
     // At this point there should be no conflicts since this is a new class.
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Deploy Source to Org successfully ran'
+      'SFDX: Deploy Source to Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -437,15 +405,11 @@ describe('Deploy and Retrieve', async () => {
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Deploy Source to Org',
+      'SFDX: Deploy Source to Org successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Deploy Source to Org successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -480,15 +444,10 @@ describe('Deploy and Retrieve', async () => {
     // Deploy running SFDX: Deploy This Source to Org
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Deploy Source to Org',
+      'SFDX: Deploy Source to Org successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Deploy Source to Org successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -31,10 +31,10 @@ describe('Deploy and Retrieve', async () => {
     ].join('\n');
     await utilities.createApexClass('MyClass', classText);
     const workbench = await (await browser.getWorkbench()).wait();
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Apex Class successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -100,7 +100,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -130,7 +130,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -168,7 +168,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -202,7 +202,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -243,7 +243,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
     const textAfterRetrieve = await textEditor.getText();
@@ -317,7 +317,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -379,7 +379,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -409,7 +409,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -447,7 +447,7 @@ describe('Deploy and Retrieve', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/manifestBuilder.e2e.ts
+++ b/test/specs/manifestBuilder.e2e.ts
@@ -77,17 +77,11 @@ describe('Manifest Builder', async () => {
       1
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Deploy Source to Org',
-      utilities.FIVE_MINUTES
-    );
-
     // Look for the success notification that appears which says, "SFDX: Deploy Source to Org successfully ran".
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Deploy Source to Org successfully ran'
+      'SFDX: Deploy Source to Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -136,17 +130,11 @@ describe('Manifest Builder', async () => {
       1
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Retrieve Source from Org',
-      utilities.FIVE_MINUTES
-    );
-
     // Look for the success notification that appears which says, "SFDX: Retrieve Source from Org successfully ran".
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Retrieve Source from Org successfully ran'
+      'SFDX: Retrieve Source from Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/manifestBuilder.e2e.ts
+++ b/test/specs/manifestBuilder.e2e.ts
@@ -81,7 +81,7 @@ describe('Manifest Builder', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -134,7 +134,7 @@ describe('Manifest Builder', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/manifestBuilder.e2e.ts
+++ b/test/specs/manifestBuilder.e2e.ts
@@ -81,7 +81,7 @@ describe('Manifest Builder', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -134,7 +134,7 @@ describe('Manifest Builder', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/manifestBuilder.e2e.ts
+++ b/test/specs/manifestBuilder.e2e.ts
@@ -81,7 +81,7 @@ describe('Manifest Builder', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Deploy Source to Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -134,7 +134,7 @@ describe('Manifest Builder', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Retrieve Source from Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -401,7 +401,7 @@ describe('Push and Pull', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -45,10 +45,10 @@ describe('Push and Pull', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Apex Class successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -95,10 +95,10 @@ describe('Push and Pull', async () => {
 
     // At this point there should be no conflicts since this is a new class.
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -120,10 +120,10 @@ describe('Push and Pull', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -151,10 +151,10 @@ describe('Push and Pull', async () => {
     // Push the file.
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    let successNotificationWasFound = await utilities.attemptToFindNotification(
+    let successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -176,10 +176,10 @@ describe('Push and Pull', async () => {
     // An now push the changes.
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
-    successNotificationWasFound = await utilities.attemptToFindNotification(
+    successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -228,10 +228,10 @@ describe('Push and Pull', async () => {
 
     // At this point there should be no conflicts since there have been no changes.
 
-    let successNotificationWasFound = await utilities.attemptToFindNotification(
+    let successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Pull Source from Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -257,10 +257,10 @@ describe('Push and Pull', async () => {
     // And pull again.
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Pull Source from Default Org', 5);
 
-    successNotificationWasFound = await utilities.attemptToFindNotification(
+    successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Pull Source from Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -291,10 +291,10 @@ describe('Push and Pull', async () => {
     // Pull the file.
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Pull Source from Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Pull Source from Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -323,10 +323,10 @@ describe('Push and Pull', async () => {
     // An now pull the changes.
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Pull Source from Default Org', 5);
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Pull Source from Default Org successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -401,7 +401,7 @@ describe('Push and Pull', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -401,7 +401,7 @@ describe('Push and Pull', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -398,9 +398,10 @@ describe('Push and Pull', async () => {
     await utilities.pause(3);
 
     // Look for the success notification.
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Set a Default Org successfully ran'
+      'SFDX: Set a Default Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/specs/runApexTests.e2e.ts
+++ b/test/specs/runApexTests.e2e.ts
@@ -38,7 +38,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -84,7 +84,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -133,7 +133,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -171,7 +171,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -239,7 +239,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -282,7 +282,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -345,7 +345,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -404,7 +404,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -451,7 +451,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
 
@@ -470,7 +470,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -508,7 +508,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotification2WasFound).toBe(true);
 
@@ -526,7 +526,7 @@ describe('Run Apex Tests', async () => {
     const successNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotification2WasFound).toBe(true);
 
@@ -566,7 +566,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Build Apex Test Suite successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
   });
@@ -594,7 +594,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Build Apex Test Suite successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
   });
@@ -617,7 +617,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/runApexTests.e2e.ts
+++ b/test/specs/runApexTests.e2e.ts
@@ -38,7 +38,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -84,7 +84,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -133,7 +133,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -171,7 +171,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -239,7 +239,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -282,7 +282,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -345,7 +345,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -404,7 +404,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -451,7 +451,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
 
@@ -470,7 +470,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -508,7 +508,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotification2WasFound).toBe(true);
 
@@ -526,7 +526,7 @@ describe('Run Apex Tests', async () => {
     const successNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotification2WasFound).toBe(true);
 
@@ -566,7 +566,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Build Apex Test Suite successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
   });
@@ -594,7 +594,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Build Apex Test Suite successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
   });
@@ -617,7 +617,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/runApexTests.e2e.ts
+++ b/test/specs/runApexTests.e2e.ts
@@ -38,7 +38,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -84,7 +84,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -133,7 +133,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -171,7 +171,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -239,7 +239,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -282,7 +282,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -345,7 +345,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -404,7 +404,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -451,7 +451,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
 
@@ -470,7 +470,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -508,7 +508,7 @@ describe('Run Apex Tests', async () => {
     const successPushNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotification2WasFound).toBe(true);
 
@@ -526,7 +526,7 @@ describe('Run Apex Tests', async () => {
     const successNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotification2WasFound).toBe(true);
 
@@ -566,7 +566,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Build Apex Test Suite successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
   });
@@ -594,7 +594,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Build Apex Test Suite successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
   });
@@ -617,7 +617,7 @@ describe('Run Apex Tests', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/sObjectsDefinitions.e2e.ts
+++ b/test/specs/sObjectsDefinitions.e2e.ts
@@ -83,7 +83,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -110,7 +110,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -206,7 +206,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -275,7 +275,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/sObjectsDefinitions.e2e.ts
+++ b/test/specs/sObjectsDefinitions.e2e.ts
@@ -83,7 +83,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -110,7 +110,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -206,7 +206,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -275,7 +275,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/sObjectsDefinitions.e2e.ts
+++ b/test/specs/sObjectsDefinitions.e2e.ts
@@ -83,7 +83,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -110,7 +110,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -206,7 +206,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -275,7 +275,7 @@ describe('SObjects Definitions', async () => {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Refresh SObject Definitions successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -40,10 +40,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Apex Class successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -116,10 +116,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Apex Trigger successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -192,10 +192,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Aura App successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -309,10 +309,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Aura Component successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -371,10 +371,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Aura Event successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -432,10 +432,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Aura Interface successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -509,10 +509,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Lightning Web Component successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -573,10 +573,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Visualforce Component successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -651,10 +651,10 @@ describe('Templates', async () => {
     // Select the default directory (press Enter/Return).
     await inputBox.confirm();
 
-    const successNotificationWasFound = await utilities.attemptToFindNotification(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Create Visualforce Page successfully ran',
-      10
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -36,7 +36,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -66,7 +66,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -134,7 +134,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -161,7 +161,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -185,7 +185,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Getting Apex debug logs',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
 
     // Select a log file
@@ -197,7 +197,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Get Apex Debug Logs successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -258,7 +258,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -275,7 +275,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -32,15 +32,11 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
       'SFDX: Push Source to Default Org and Override Conflicts',
       1
     );
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+
+    const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successPushNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran'
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -67,27 +63,10 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // Select the "AccountServiceTest" file
     await prompt.selectQuickPick('AccountServiceTest');
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Run Apex Tests',
+      'SFDX: Run Apex Tests successfully ran',
       utilities.FIVE_MINUTES
-    );
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Run Apex Tests: Listening for streaming state changes...',
-      utilities.FIVE_MINUTES
-    );
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Run Apex Tests: Processing test run',
-      utilities.FIVE_MINUTES,
-      false
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Run Apex Tests successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -151,17 +130,11 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
       10
     );
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Turn On Apex Debug Log for Replay Debugger',
-      utilities.FIVE_MINUTES
-    );
-
     // Look for the success notification that appears which says, "SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran".
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran'
+      'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
+      utilities.FIVE_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -185,27 +158,10 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // Select the "AccountServiceTest" file
     await prompt.selectQuickPick('AccountServiceTest');
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Run Apex Tests',
+      'SFDX: Run Apex Tests successfully ran',
       utilities.FIVE_MINUTES
-    );
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Run Apex Tests: Listening for streaming state changes...',
-      utilities.FIVE_MINUTES
-    );
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Run Apex Tests: Processing test run',
-      utilities.FIVE_MINUTES,
-      false
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Run Apex Tests successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -238,16 +194,10 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     expect(quickPicks.length).toBeGreaterThanOrEqual(1);
     await prompt.selectQuickPick('User User - ApexTestHandler');
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Get Apex Debug Logs',
+      'SFDX: Get Apex Debug Logs successfully ran',
       utilities.FIVE_MINUTES
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Get Apex Debug Logs successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -304,15 +254,11 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
       'SFDX: Push Source to Default Org and Override Conflicts',
       1
     );
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+
+    const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
       utilities.FIVE_MINUTES
-    );
-    const successPushNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran'
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -326,27 +272,10 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // Select the "AccountServiceTest" file
     await prompt.selectQuickPick('AccountServiceTest');
 
-    // Wait for the command to execute
-    await utilities.waitForNotificationToGoAway(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'Running SFDX: Run Apex Tests',
+      'SFDX: Run Apex Tests successfully ran',
       utilities.FIVE_MINUTES
-    );
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Run Apex Tests: Listening for streaming state changes...',
-      utilities.FIVE_MINUTES
-    );
-    await utilities.waitForNotificationToGoAway(
-      workbench,
-      'Running SFDX: Run Apex Tests: Processing test run',
-      utilities.FIVE_MINUTES,
-      false
-    );
-
-    const successNotificationWasFound = await utilities.notificationIsPresent(
-      workbench,
-      'SFDX: Run Apex Tests successfully ran'
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -36,7 +36,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -66,7 +66,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -134,7 +134,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -161,7 +161,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -185,7 +185,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Getting Apex debug logs',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
 
     // Select a log file
@@ -197,7 +197,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Get Apex Debug Logs successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -258,7 +258,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -275,7 +275,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -36,7 +36,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -66,7 +66,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -134,7 +134,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Turn On Apex Debug Log for Replay Debugger successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -161,7 +161,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -185,7 +185,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     await utilities.waitForNotificationToGoAway(
       workbench,
       'Getting Apex debug logs',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
 
     // Select a log file
@@ -197,7 +197,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Get Apex Debug Logs successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 
@@ -258,7 +258,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
   });
@@ -275,7 +275,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Run Apex Tests successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     expect(successNotificationWasFound).toBe(true);
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -367,7 +367,7 @@ export class TestSetup {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(
@@ -412,7 +412,7 @@ export class TestSetup {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.TEN_MINUTES
+      utilities.FIFTEEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -179,8 +179,7 @@ export class TestSetup {
     const authFilePath = path.join(this.projectFolderPath!, 'authFile.json');
     utilities.log(`${this.testSuiteSuffixName} - calling sfdx force:org:display...`);
     const sfdxForceOrgDisplayResult = await exec(
-      `sfdx force:org:display -u ${
-        EnvironmentSettings.getInstance().devHubAliasName
+      `sfdx force:org:display -u ${EnvironmentSettings.getInstance().devHubAliasName
       } --verbose --json`
     );
     const json = this.removedEscapedCharacters(sfdxForceOrgDisplayResult.stdout);
@@ -198,8 +197,7 @@ export class TestSetup {
       )
     ) {
       throw new Error(
-        `In authorizeDevHub(), sfdxSfdxUrlStoreResult does not contain "Successfully authorized ${
-          EnvironmentSettings.getInstance().devHubUserName
+        `In authorizeDevHub(), sfdxSfdxUrlStoreResult does not contain "Successfully authorized ${EnvironmentSettings.getInstance().devHubUserName
         } with org ID"`
       );
     }
@@ -369,7 +367,7 @@ export class TestSetup {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(
@@ -414,7 +412,7 @@ export class TestSetup {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIVE_MINUTES
+      utilities.TEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -367,7 +367,7 @@ export class TestSetup {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(
@@ -412,7 +412,7 @@ export class TestSetup {
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
       'SFDX: Set a Default Org successfully ran',
-      utilities.FIFTEEN_MINUTES
+      utilities.TEN_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -366,9 +366,10 @@ export class TestSetup {
     // they are looking for.
 
     // Look for the success notification.
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Set a Default Org successfully ran'
+      'SFDX: Set a Default Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(
@@ -410,9 +411,10 @@ export class TestSetup {
 
     await utilities.pause(3);
 
-    const successNotificationWasFound = await utilities.notificationIsPresent(
+    const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Set a Default Org successfully ran'
+      'SFDX: Set a Default Org successfully ran',
+      utilities.FIVE_MINUTES
     );
     if (!successNotificationWasFound) {
       throw new Error(

--- a/test/utilities/miscellaneous.ts
+++ b/test/utilities/miscellaneous.ts
@@ -14,6 +14,7 @@ import {
 } from '../environmentSettings';
 
 export const FIVE_MINUTES = 5 * 60;
+export const TEN_MINUTES = 10 * 60;
 
 export async function pause(durationInSeconds: number): Promise<void> {
   await sleep(durationInSeconds * EnvironmentSettings.getInstance().throttleFactor * 1000);

--- a/test/utilities/miscellaneous.ts
+++ b/test/utilities/miscellaneous.ts
@@ -14,7 +14,7 @@ import {
 } from '../environmentSettings';
 
 export const FIVE_MINUTES = 5 * 60;
-export const TEN_MINUTES = 10 * 60;
+export const FIFTEEN_MINUTES = 15 * 60;
 
 export async function pause(durationInSeconds: number): Promise<void> {
   await sleep(durationInSeconds * EnvironmentSettings.getInstance().throttleFactor * 1000);

--- a/test/utilities/miscellaneous.ts
+++ b/test/utilities/miscellaneous.ts
@@ -14,7 +14,7 @@ import {
 } from '../environmentSettings';
 
 export const FIVE_MINUTES = 5 * 60;
-export const FIFTEEN_MINUTES = 15 * 60;
+export const TEN_MINUTES = 10 * 60;
 
 export async function pause(durationInSeconds: number): Promise<void> {
   await sleep(durationInSeconds * EnvironmentSettings.getInstance().throttleFactor * 1000);


### PR DESCRIPTION
Our E2E tests rely on notification checking to make sure that commands are successfully run.  This PR improves the consistency of the notification checking process so that E2E tests don't frequently fail during this step.

### Original Behavior:
In every run of all E2E tests, there were 1-3 jobs that would fail during notification checking because of the following reasons:

1. The notification is fading away / already disappeared before the check was conducted
2. The command is still running and the success notification did not appear yet

This is happening because the amount of time it takes for a command to finish running fluctuates between different test runs and different OS.  It's difficult to catch the exact timing of the notifications' presence.

### Improved Behavior:
All runs of E2E tests stop failing during the notifications checking step of the workflow.

### Key Changes Made:
1. Replace all calls to notificationIsPresent() with notificationIsPresentWithTimeout().  This allows for repeated checking for the presence of the notification within a given period of time instead of just doing one check.
2. Remove all calls to waitForNotificationToGoAway() that are placed directly before calls to notificationIsPresent() because they are no longer needed.
3. Replace all calls to attemptToFindNotification() with notificationIsPresentWithTimeout().  Now, searching for notifications takes place during a set amount of time instead of a set number of tries.
4. Increase the timeout of calls to notificationIsPresentIWithTimeout() from 5 minutes to 10 minutes.  This ensures that all commands have enough time to finish running before their success notifications are being checked.

### Successful Run:
- [492](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/6330709049) (The second and third attempts were needed because some tests failed during setup)

@W-14096102@