### PR TITLE
Fix Common Setup Errors in E2E Tests

### DIFF
--- a/test/TBD/lwcLsp.e2e.ts
+++ b/test/TBD/lwcLsp.e2e.ts
@@ -42,6 +42,10 @@ describe('LWC LSP', async () => {
     );
     // Get open text editor
     const workbench = await browser.getWorkbench();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('lwc1.js');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lwc1.js')) as TextEditor;
     await textEditor.moveCursor(3, 40);
@@ -60,6 +64,10 @@ describe('LWC LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition (HTML)`);
     // Get open text editor
     const workbench = await browser.getWorkbench();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('lwc1.html');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lwc1.html')) as TextEditor;
     await textEditor.moveCursor(3, 52);
@@ -78,6 +86,10 @@ describe('LWC LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await browser.getWorkbench();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('lwc1.html');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lwc1.html')) as TextEditor;
     await textEditor.typeTextAt(3, 7, ' lwc');

--- a/test/TBD/lwcLsp.e2e.ts
+++ b/test/TBD/lwcLsp.e2e.ts
@@ -32,7 +32,7 @@ describe('LWC LSP', async () => {
     await utilities.enableLwcExtension();
 
     // Verify Lightning Web Components extension is present and running
-    const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(workbench, 'salesforce.salesforcedx-vscode-lwc');
+    const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(workbench, 'salesforcedx-vscode-lwc');
     expect(extensionWasFound).toBe(true);
   });
 

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -103,30 +103,7 @@ describe('An Initial Suite', async () => {
   });
 
   step('Verify our extensions are loaded after creating an SFDX project', async () => {
-    const workbench = await (await browser.getWorkbench()).wait();
-    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 3);
-    await utilities.enableLwcExtension();
-    // Close panel and clear all notifications so all extensions can be seen
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
-    await utilities.runCommandFromCommandPrompt(
-      workbench,
-      'Notifications: Clear All Notifications',
-      1
-    );
-
-    let matchesFound = 0;
-    const extensionNameDivs = await $$('div.name');
-    for (const extensionNameDiv of extensionNameDivs) {
-      const text = await extensionNameDiv.getText();
-
-      if (text.startsWith('salesforce.salesforcedx-vscode-')) {
-        matchesFound++;
-        utilities.log(`AnInitialSuite - extension ${text} is loaded`);
-      }
-    }
-
-    // 7 are in the list, but sometimes only 6 are visible.
-    expect(matchesFound).toBeGreaterThanOrEqual(6);
+    testSetup.verifyAllExtensionsAreRunning();
   });
 
   step('Verify that SFDX commands are present after an SFDX project has been created', async () => {

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -114,9 +114,6 @@ describe('An Initial Suite', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const prompt = await utilities.openCommandPromptWithCommand(workbench, 'SFDX:');
     const quickPicks = await prompt.getQuickPicks();
-    // throw error for screenshot
-    let x = 0;
-    expect(x).toBe(2);
     const commands: string[] = [];
     for (const quickPick of quickPicks) {
       commands.push(await quickPick.getLabel());

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -106,6 +106,8 @@ describe('An Initial Suite', async () => {
     utilities.verifyAllExtensionsAreRunning();
     browser.keys(['Escape']);
     await utilities.pause(1);
+    browser.keys(['Escape']);
+    await utilities.pause(1);
   });
 
   step('Verify that SFDX commands are present after an SFDX project has been created', async () => {

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -103,17 +103,13 @@ describe('An Initial Suite', async () => {
   });
 
   step('Verify our extensions are loaded after creating an SFDX project', async () => {
-    utilities.log('1');
     testSetup.verifyAllExtensionsAreRunning();
-    utilities.log('2');
+    browser.keys(['Escape']);
   });
 
   step('Verify that SFDX commands are present after an SFDX project has been created', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const prompt = await utilities.openCommandPromptWithCommand(workbench, 'SFDX:');
-    // throw error to see screenshot - remove this later
-    let x = 0;
-    expect(x).toBe(5);
     const quickPicks = await prompt.getQuickPicks();
     const commands: string[] = [];
     for (const quickPick of quickPicks) {

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -103,7 +103,7 @@ describe('An Initial Suite', async () => {
   });
 
   step('Verify our extensions are loaded after creating an SFDX project', async () => {
-    testSetup.verifyAllExtensionsAreRunning();
+    utilities.verifyAllExtensionsAreRunning();
     browser.keys(['Escape']);
     await utilities.pause(1);
   });

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -105,6 +105,7 @@ describe('An Initial Suite', async () => {
   step('Verify our extensions are loaded after creating an SFDX project', async () => {
     testSetup.verifyAllExtensionsAreRunning();
     browser.keys(['Escape']);
+    await utilities.pause(1);
   });
 
   step('Verify that SFDX commands are present after an SFDX project has been created', async () => {

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -112,6 +112,9 @@ describe('An Initial Suite', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const prompt = await utilities.openCommandPromptWithCommand(workbench, 'SFDX:');
     const quickPicks = await prompt.getQuickPicks();
+    // throw error for screenshot
+    let x = 0;
+    expect(x).toBe(2);
     const commands: string[] = [];
     for (const quickPick of quickPicks) {
       commands.push(await quickPick.getLabel());

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -103,12 +103,17 @@ describe('An Initial Suite', async () => {
   });
 
   step('Verify our extensions are loaded after creating an SFDX project', async () => {
+    utilities.log('1');
     testSetup.verifyAllExtensionsAreRunning();
+    utilities.log('2');
   });
 
   step('Verify that SFDX commands are present after an SFDX project has been created', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     const prompt = await utilities.openCommandPromptWithCommand(workbench, 'SFDX:');
+    // throw error to see screenshot - remove this later
+    let x = 0;
+    expect(x).toBe(5);
     const quickPicks = await prompt.getQuickPicks();
     const commands: string[] = [];
     for (const quickPick of quickPicks) {

--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -64,6 +64,10 @@ describe('Apex LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleClassTest.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleClassTest.cls')) as TextEditor;
     await textEditor.moveCursor(6, 20);
@@ -82,6 +86,10 @@ describe('Apex LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleClassTest.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleClassTest.cls')) as TextEditor;
     await textEditor.typeTextAt(7, 1, '\tExampleClass.s');

--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -34,7 +34,7 @@ describe('Apex LSP', async () => {
     // Verify Apex extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex'
+      'salesforcedx-vscode-apex'
     );
     expect(extensionWasFound).toBe(true);
   });

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -59,7 +59,7 @@ describe('Apex Replay Debugger', async () => {
     // Reloading the window forces the extensions to be reloaded and this seems to fix
     // the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
-    testSetup.verifyAllExtensionsAreRunning();
+    await testSetup.verifyAllExtensionsAreRunning();
 
     // Clear output before running the command
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -59,6 +59,7 @@ describe('Apex Replay Debugger', async () => {
     // Reloading the window forces the extensions to be reloaded and this seems to fix
     // the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
+    testSetup.verifyAllExtensionsAreRunning();
 
     // Clear output before running the command
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -59,7 +59,7 @@ describe('Apex Replay Debugger', async () => {
     // Reloading the window forces the extensions to be reloaded and this seems to fix
     // the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
-    await testSetup.verifyAllExtensionsAreRunning();
+    await utilities.verifyAllExtensionsAreRunning();
 
     // Clear output before running the command
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -90,6 +90,10 @@ describe('Apex Replay Debugger', async () => {
   step('Run the Anonymous Apex Debugger with Currently Selected Text', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleApexClassTest.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     (await editorView.openEditor('ExampleApexClassTest.cls')) as TextEditor;
 

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -33,7 +33,7 @@ describe('Aura LSP', async () => {
     // Verify Aura Components extension is present and running.
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-lightning'
+      'salesforcedx-vscode-lightning'
     );
     expect(extensionWasFound).toBe(true);
   });

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -42,6 +42,10 @@ describe('Aura LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('aura1.cmp');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('aura1.cmp')) as TextEditor;
 
@@ -67,6 +71,10 @@ describe('Aura LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('aura1.cmp');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('aura1.cmp')) as TextEditor;
     await textEditor.typeTextAt(2, 1, '<aura');

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -32,7 +32,7 @@ describe('Authentication', async () => {
     // Reloading the window forces the extensions to be reloaded and this seems to fix
     // the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
-    testSetup.verifyAllExtensionsAreRunning();
+    await testSetup.verifyAllExtensionsAreRunning();
 
     // In the initial state, the org picker button should be set to "No Default Org Set".
     let noDefaultOrgSetItem = await utilities.getStatusBarItemWhichIncludes(

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -31,8 +31,9 @@ describe('Authentication', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Reloading the window forces the extensions to be reloaded and this seems to fix
     // the issue.
-    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 10);
-    await utilities.pause(20);
+    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
+    testSetup.verifyAllExtensionsAreRunning();
+
     // In the initial state, the org picker button should be set to "No Default Org Set".
     let noDefaultOrgSetItem = await utilities.getStatusBarItemWhichIncludes(
       workbench,

--- a/test/specs/authentication.e2e.ts
+++ b/test/specs/authentication.e2e.ts
@@ -32,7 +32,7 @@ describe('Authentication', async () => {
     // Reloading the window forces the extensions to be reloaded and this seems to fix
     // the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
-    await testSetup.verifyAllExtensionsAreRunning();
+    await utilities.verifyAllExtensionsAreRunning();
 
     // In the initial state, the org picker button should be set to "No Default Org Set".
     let noDefaultOrgSetItem = await utilities.getStatusBarItemWhichIncludes(

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -88,10 +88,10 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST enabled', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
-    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -119,10 +119,10 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Deploy again (with no changes) - ST enabled', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
-    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -151,12 +151,12 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Modify the file and deploy again - ST enabled', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
-    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, '\t//say hello to a given name');
@@ -187,10 +187,10 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Retrieve with SFDX: Retrieve This Source from Org', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
-    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(
@@ -221,12 +221,12 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Modify the file and retrieve again', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by changing the comment.
-    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, '\t//modified comment');
@@ -265,11 +265,11 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Prefer Deploy on Save when `Push or deploy on save` is enabled', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     let outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
-    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
       'Preferences: Open Workspace Settings',
@@ -305,7 +305,7 @@ describe('Deploy and Retrieve', async () => {
 
     // Clear the Output view first.
     outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     // Modify the file and save to trigger deploy
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
@@ -370,7 +370,7 @@ describe('Deploy and Retrieve', async () => {
     );
     // Clear the Output view first.
     const outputView = await (await utilities.openOutputView()).wait();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -398,10 +398,10 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Deploy again (with no changes) - ST disabled', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
-    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -430,12 +430,12 @@ describe('Deploy and Retrieve', async () => {
   });
 
   step('Modify the file and deploy again - ST disabled', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
-    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, '\t//say hello to a given name');

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -388,7 +388,7 @@ describe('Deploy and Retrieve', async () => {
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 50);
-    testSetup.verifyAllExtensionsAreRunning();
+    await testSetup.verifyAllExtensionsAreRunning();
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -90,7 +90,7 @@ describe('Deploy and Retrieve', async () => {
   step('Deploy with SFDX: Deploy This Source to Org - ST enabled', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
     await inputBox.setText('MyClass.cls');
@@ -125,7 +125,7 @@ describe('Deploy and Retrieve', async () => {
   step('Deploy again (with no changes) - ST enabled', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
     await inputBox.setText('MyClass.cls');
@@ -161,7 +161,7 @@ describe('Deploy and Retrieve', async () => {
   step('Modify the file and deploy again - ST enabled', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
@@ -201,7 +201,7 @@ describe('Deploy and Retrieve', async () => {
   step('Retrieve with SFDX: Retrieve This Source from Org', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
     await inputBox.setText('MyClass.cls');
@@ -239,7 +239,7 @@ describe('Deploy and Retrieve', async () => {
   step('Modify the file and retrieve again', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by changing the comment.
@@ -400,7 +400,7 @@ describe('Deploy and Retrieve', async () => {
       1
     );
     // Clear the Output view first.
-    const outputView = await (await utilities.openOutputView()).wait();
+    await (await utilities.openOutputView()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
     await inputBox.setText('MyClass.cls');
@@ -435,7 +435,7 @@ describe('Deploy and Retrieve', async () => {
   step('Deploy again (with no changes) - ST disabled', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
     await inputBox.setText('MyClass.cls');
@@ -471,7 +471,7 @@ describe('Deploy and Retrieve', async () => {
   step('Modify the file and deploy again - ST disabled', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -388,6 +388,7 @@ describe('Deploy and Retrieve', async () => {
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 50);
+    testSetup.verifyAllExtensionsAreRunning();
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -92,6 +92,10 @@ describe('Deploy and Retrieve', async () => {
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -123,6 +127,10 @@ describe('Deploy and Retrieve', async () => {
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -157,6 +165,10 @@ describe('Deploy and Retrieve', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, '\t//say hello to a given name');
@@ -191,6 +203,10 @@ describe('Deploy and Retrieve', async () => {
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(
@@ -227,6 +243,10 @@ describe('Deploy and Retrieve', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by changing the comment.
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, '\t//modified comment');
@@ -313,6 +333,10 @@ describe('Deploy and Retrieve', async () => {
     outputView = await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
     // Modify the file and save to trigger deploy
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, `\t// let's trigger deploy`);
@@ -377,6 +401,10 @@ describe('Deploy and Retrieve', async () => {
     // Clear the Output view first.
     const outputView = await (await utilities.openOutputView()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -408,6 +436,10 @@ describe('Deploy and Retrieve', async () => {
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Deploy This Source to Org', 5);
@@ -442,6 +474,10 @@ describe('Deploy and Retrieve', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('MyClass.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('MyClass.cls')) as TextEditor;
     await textEditor.setTextAtLine(2, '\t//say hello to a given name');

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -290,6 +290,12 @@ describe('Deploy and Retrieve', async () => {
     );
     await browser.keys(['prefer deploy']);
 
+    try {
+      await utilities.runCommandFromCommandPrompt(workbench, 'View: Close Panel', 2);
+    }
+    catch {
+      utilities.log('Panel is already closed');
+    }
     const preferDeployOnSaveBtn = await $(
       'div[title="salesforcedx-vscode-core.push-or-deploy-on-save.preferDeployOnSave"]'
     );

--- a/test/specs/deployAndRetrieve.e2e.ts
+++ b/test/specs/deployAndRetrieve.e2e.ts
@@ -388,7 +388,7 @@ describe('Deploy and Retrieve', async () => {
     await utilities.pause(1);
     // Reload window to update cache and get the setting behavior to work
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 50);
-    await testSetup.verifyAllExtensionsAreRunning();
+    await utilities.verifyAllExtensionsAreRunning();
   });
 
   step('Deploy with SFDX: Deploy This Source to Org - ST disabled', async () => {

--- a/test/specs/manifestBuilder.e2e.ts
+++ b/test/specs/manifestBuilder.e2e.ts
@@ -46,6 +46,10 @@ describe('Manifest Builder', async () => {
     await inputBox.confirm();
     await inputBox.confirm();
 
+    const inputBox2 = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox2.setText('manifest.xml');
+    await inputBox2.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('manifest.xml')) as TextEditor;
     const content = [
@@ -120,6 +124,10 @@ describe('Manifest Builder', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - SFDX: Retrieve Source in Manifest from Org`);
     // Using the Command palette, run SFDX: Retrieve Source in Manifest from Org
     const workbench = await browser.getWorkbench();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('manifest.xml');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     await editorView.openEditor('manifest.xml');
     // Clear output before running the command

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -24,7 +24,7 @@ describe('Push and Pull', async () => {
 
   step('Set up the testing environment', async () => {
     testSetup = new TestSetup('PushAndPull', false);
-    await testSetup.setUp('Enterprise');
+    await testSetup.setUp();
     projectName = testSetup.tempProjectName.toUpperCase();
   });
 

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -116,7 +116,7 @@ describe('Push and Pull', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
 
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
@@ -142,7 +142,7 @@ describe('Push and Pull', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
 
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
@@ -227,7 +227,7 @@ describe('Push and Pull', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
 
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Pull Source from Default Org', 5);
@@ -286,7 +286,8 @@ describe('Push and Pull', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
 
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
     const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
@@ -323,7 +324,7 @@ describe('Push and Pull', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
 
     // Clear the Output view first.
-    const outputView = await utilities.openOutputView();
+    await utilities.openOutputView();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Now save the file.

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -146,6 +146,10 @@ describe('Push and Pull', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleApexClass1.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleApexClass1.cls')) as TextEditor;
     await textEditor.setTextAtLine(3, '        // sample comment');
@@ -285,6 +289,10 @@ describe('Push and Pull', async () => {
     const outputView = await utilities.openOutputView();
 
     // Modify the file by adding a comment.
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleApexClass1.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleApexClass1.cls')) as TextEditor;
     await textEditor.setTextAtLine(3, '        // sample comment for the pull test');
@@ -319,6 +327,10 @@ describe('Push and Pull', async () => {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Now save the file.
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ExampleApexClass1.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleApexClass1.cls')) as TextEditor;
     await textEditor.save();

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -117,7 +117,6 @@ describe('Push and Pull', async () => {
 
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    // await outputView.clearText();
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
@@ -140,12 +139,13 @@ describe('Push and Pull', async () => {
   });
 
   step('Modify the file and push the changes', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
+
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Modify the file by adding a comment.
-    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleApexClass1.cls')) as TextEditor;
     await textEditor.setTextAtLine(3, '        // sample comment');
@@ -170,7 +170,7 @@ describe('Push and Pull', async () => {
     expect(outputPanelText).toContain('No results found');
 
     // Clear the Output view again.
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Now save the file.
     await textEditor.save();
@@ -220,12 +220,12 @@ describe('Push and Pull', async () => {
 
   step('Pull the Apex class', async () => {
     // With this test, it's going to pull twice...
+    const workbench = await (await browser.getWorkbench()).wait();
 
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
-    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Pull Source from Default Org', 5);
 
     // At this point there should be no conflicts since there have been no changes.
@@ -254,7 +254,7 @@ describe('Push and Pull', async () => {
 
     // Second pull...
     // Clear the output again.
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // And pull again.
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Pull Source from Default Org', 5);
@@ -279,12 +279,12 @@ describe('Push and Pull', async () => {
   });
 
   step("Modify the file (but don't save), then pull", async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
+
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
 
     // Modify the file by adding a comment.
-    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleApexClass1.cls')) as TextEditor;
     await textEditor.setTextAtLine(3, '        // sample comment for the pull test');
@@ -312,12 +312,13 @@ describe('Push and Pull', async () => {
   });
 
   step('Save the modified file, then pull', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
+
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
     // Now save the file.
-    const workbench = await (await browser.getWorkbench()).wait();
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ExampleApexClass1.cls')) as TextEditor;
     await textEditor.save();

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -113,11 +113,13 @@ describe('Push and Pull', async () => {
   });
 
   step('Push again (with no changes)', async () => {
+    const workbench = await (await browser.getWorkbench()).wait();
+
     // Clear the Output view first.
     const outputView = await utilities.openOutputView();
-    await outputView.clearText();
+    // await outputView.clearText();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Clear Output', 2);
 
-    const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Push Source to Default Org', 5);
 
     const successNotificationWasFound = await utilities.notificationIsPresentWithTimeout(

--- a/test/specs/templates.e2e.ts
+++ b/test/specs/templates.e2e.ts
@@ -91,6 +91,10 @@ describe('Templates', async () => {
       '}'
     ].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ApexClass1.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexClass1.cls')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -167,6 +171,10 @@ describe('Templates', async () => {
     // Verify the default trigger.
     const expectedText = ['trigger ApexTrigger1 on SOBJECT (before insert) {', '', '}'].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('ApexTrigger1.trigger');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('ApexTrigger1.trigger')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -285,6 +293,10 @@ describe('Templates', async () => {
     // Verify the default code for an Aura App.
     const expectedText = ['<aura:application>', '', '</aura:application>'].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('AuraApp1.app');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraApp1.app')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -347,6 +359,10 @@ describe('Templates', async () => {
   step('Verify the contents of the Aura Component', async () => {
     const expectedText = ['<aura:component>', '', '</aura:component>'].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('auraComponent1.cmp');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraComponent1.cmp')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -407,6 +423,10 @@ describe('Templates', async () => {
       '\n'
     );
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('auraEvent1.evt');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('auraEvent1.evt')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -485,6 +505,10 @@ describe('Templates', async () => {
       '</aura:interface>'
     ].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('AuraInterface1.intf');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AuraInterface1.intf')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -548,6 +572,10 @@ describe('Templates', async () => {
       'export default class LightningWebComponent1 extends LightningElement {}'
     ].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('lightningWebComponent1.js');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('lightningWebComponent1.js')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -626,6 +654,10 @@ describe('Templates', async () => {
       '</apex:component>'
     ].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('VisualforceCmp1.component');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforceCmp1.component')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');
@@ -704,6 +736,10 @@ describe('Templates', async () => {
       '</apex:page>'
     ].join('\n');
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('VisualforcePage1.page');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = await workbench.getEditorView();
     const textEditor = (await editorView.openEditor('VisualforcePage1.page')) as TextEditor;
     const textGeneratedFromTemplate = (await textEditor.getText()).trimEnd().replace(/\r\n/g, '\n');

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -99,7 +99,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // it does not complete the 6 steps but only 4.
     // Reloading the window forces the extensions to be reloaded and this seems to fix the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
-    await testSetup.verifyAllExtensionsAreRunning();
+    await utilities.verifyAllExtensionsAreRunning();
 
     // Switch back to the AccountService.cls tab
     const inputBox2 = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -99,7 +99,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // it does not complete the 6 steps but only 4.
     // Reloading the window forces the extensions to be reloaded and this seems to fix the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
-    testSetup.verifyAllExtensionsAreRunning();
+    await testSetup.verifyAllExtensionsAreRunning();
 
     // Verify checkpoint is present
     const breakpoints = await $$('.codicon-debug-breakpoint-conditional');

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -84,6 +84,10 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
   step('Set Breakpoints and Checkpoints', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('AccountService.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AccountService.cls')) as TextEditor;
     await textEditor.moveCursor(8, 5);
@@ -241,6 +245,10 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
   step('Push Fixed Metadata to Org', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('AccountService.cls');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('AccountService.cls')) as TextEditor;
     await textEditor.setTextAtLine(6, '\t\t\tTickerSymbol = tickerSymbol');

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -101,6 +101,14 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
     await testSetup.verifyAllExtensionsAreRunning();
 
+    // Switch back to the AccountService.cls tab
+    const inputBox2 = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox2.setText('AccountService.cls');
+    await inputBox2.confirm();
+    await utilities.pause(1);
+    const editorView2 = workbench.getEditorView();
+    (await editorView2.openEditor('AccountService.cls')) as TextEditor;
+
     // Verify checkpoint is present
     const breakpoints = await $$('.codicon-debug-breakpoint-conditional');
     expect(breakpoints.length).toEqual(1);

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -99,6 +99,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // it does not complete the 6 steps but only 4.
     // Reloading the window forces the extensions to be reloaded and this seems to fix the issue.
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 30);
+    testSetup.verifyAllExtensionsAreRunning();
 
     // Verify checkpoint is present
     const breakpoints = await $$('.codicon-debug-breakpoint-conditional');

--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -52,6 +52,10 @@ describe('Visualforce LSP', async () => {
     expect(outputPanelText).toContain('Finished SFDX: Create Visualforce Page');
 
     // Get open text editor and verify file content
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('FooPage.page');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('FooPage.page')) as TextEditor;
     const fileContent = await textEditor.getText();
@@ -82,6 +86,10 @@ describe('Visualforce LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('FooPage.page');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('FooPage.page')) as TextEditor;
     await textEditor.moveCursor(1, 25);
@@ -102,6 +110,10 @@ describe('Visualforce LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
+    const inputBox = await utilities.runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+    await inputBox.setText('FooPage.page');
+    await inputBox.confirm();
+    await utilities.pause(1);
     const editorView = workbench.getEditorView();
     const textEditor = (await editorView.openEditor('FooPage.page')) as TextEditor;
     await textEditor.typeTextAt(3, 1, '\t\t<apex:pageM');

--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -73,7 +73,7 @@ describe('Visualforce LSP', async () => {
     // Verify Visualforce extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-visualforce'
+      'salesforcedx-vscode-visualforce'
     );
     expect(extensionWasFound).toBe(true);
   });

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -196,7 +196,7 @@ export class TestSetup {
     // Verify Apex Replay Debugger extension is present and running
     const ardExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex-replay-debugge'
+      'salesforce.salesforcedx-vscode-apex-replay-debugger'
     );
     expect(ardExtensionWasFound).toBe(true);
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -42,6 +42,7 @@ export class TestSetup {
     utilities.log(`${this.testSuiteSuffixName} - Starting TestSetup.setUp()...`);
     await this.setUpTestingEnvironment();
     await this.createProject(scratchOrgEdition);
+    await this.verifyAllExtensionsAreRunning();
     await this.authorizeDevHub();
     await this.createDefaultScratchOrg();
     await this.disableCommandCenter();
@@ -163,6 +164,83 @@ export class TestSetup {
 
     utilities.log(`${this.testSuiteSuffixName} - ...finished createProject()`);
     utilities.log('');
+  }
+
+  public async verifyAllExtensionsAreRunning(): Promise<void> {
+    utilities.log('');
+    utilities.log(`${this.testSuiteSuffixName} - Starting verifyAllExtensionsAreRunning()...`);
+
+    // Using the Command palette, run Developer: Show Running Extensions
+    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.showRunningExtensions(workbench);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+    utilities.pause(10);
+
+    // Verify CLI Integration extension is present and running
+    const coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-core'
+    );
+    expect(coreExtensionWasFound).toBe(true);
+
+    // Verify Apex extension is present and running
+    const apexExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-apex'
+    );
+    expect(apexExtensionWasFound).toBe(true);
+
+    // Verify Apex Replay Debugger extension is present and running
+    const ardExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-apex-replay-debugger'
+    );
+    expect(ardExtensionWasFound).toBe(true);
+
+    // Verify Apex Interactive Debugger extension is present and running
+    const isvExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-apex-debugger'
+    );
+    expect(isvExtensionWasFound).toBe(true);
+
+    // Verify SOQL extension is present and running
+    const soqlExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-soql'
+    );
+    expect(soqlExtensionWasFound).toBe(true);
+
+    // Verify Aura extension is present and running
+    const auraExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-lightning'
+    );
+    expect(auraExtensionWasFound).toBe(true);
+
+    // Verify Visualforce extension is present and running
+    const vfExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-visualforce'
+    );
+    expect(vfExtensionWasFound).toBe(true);
+
+    // Verify LWC extension is present and running
+    const lwcExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforce.salesforcedx-vscode-lwc'
+    );
+    expect(lwcExtensionWasFound).toBe(true);
+
+    utilities.pause(2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+    utilities.pause(2);
   }
 
   public async authorizeDevHub(): Promise<void> {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -128,8 +128,8 @@ export class TestSetup {
     // If you are not in a VSCode project, the Salesforce extensions are not running
     // Force the CLI integration extension to load before creating the project
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
-    this.prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 1);
-    // await browser.keys(['Escape']);
+    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 1);
+    await browser.keys(['Escape']);
 
     // Do not continue until we verify CLI Integration extension is present and running
     let coreExtensionWasFound = false;
@@ -144,7 +144,7 @@ export class TestSetup {
     while (coreExtensionWasFound === false);
     utilities.log(`${this.testSuiteSuffixName} - Ready to create the standard project`);
 
-    // this.prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 5);
+    this.prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 5);
     // Selecting "SFDX: Create Project" causes the extension to be loaded, and this takes a while.
 
     // Select the "Standard" project type.

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -128,13 +128,13 @@ export class TestSetup {
     // If you are not in a VSCode project, the Salesforce extensions are not running
     // Force the CLI integration extension to load before creating the project
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 10);
-    await browser.keys(['Escape']);
+    this.prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 1);
+    // await browser.keys(['Escape']);
 
     // Do not continue until we verify CLI Integration extension is present and running
     let coreExtensionWasFound = false;
     do {
-      await utilities.pause(30);
+      await utilities.pause(5);
 
       coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
         workbench,
@@ -144,7 +144,7 @@ export class TestSetup {
     while (coreExtensionWasFound === false);
     utilities.log(`${this.testSuiteSuffixName} - Ready to create the standard project`);
 
-    this.prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 5);
+    // this.prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 5);
     // Selecting "SFDX: Create Project" causes the extension to be loaded, and this takes a while.
 
     // Select the "Standard" project type.

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -128,13 +128,13 @@ export class TestSetup {
     // If you are not in a VSCode project, the Salesforce extensions are not running
     // Force the CLI integration extension to load before creating the project
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 10);
     await browser.keys(['Escape']);
 
     // Do not continue until we verify CLI Integration extension is present and running
     let coreExtensionWasFound = false;
     do {
-      await utilities.pause(5);
+      await utilities.pause(30);
 
       coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
         workbench,

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -131,6 +131,8 @@ export class TestSetup {
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
     await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 5);
     await browser.keys(['Escape']);
+    await utilities.pause(1);
+    await browser.keys(['Escape']);
 
     // Do not continue until we verify CLI Integration extension is present and running
     let coreExtensionWasFound = false;

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -180,10 +180,6 @@ export class TestSetup {
 
     utilities.log(`${this.testSuiteSuffixName} - ...finished createProject()`);
     utilities.log('');
-
-    // THROW ERROR HERE - remove when done
-    let x = 0;
-    expect(x).toBe(1);
   }
 
   public async verifyAllExtensionsAreRunning(): Promise<void> {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -128,7 +128,7 @@ export class TestSetup {
     // If you are not in a VSCode project, the Salesforce extensions are not running
     // Force the CLI integration extension to load before creating the project
     await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
-    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 10);
+    await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Create Project', 5);
     await browser.keys(['Escape']);
 
     // Do not continue until we verify CLI Integration extension is present and running

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -228,12 +228,12 @@ export class TestSetup {
     );
     expect(vfExtensionWasFound).toBe(true);
 
-    // Verify LWC extension is present and running
-    const lwcExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforce.salesforcedx-vscode-lwc'
-    );
-    expect(lwcExtensionWasFound).toBe(true);
+    // // Verify LWC extension is present and running
+    // const lwcExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+    //   workbench,
+    //   'salesforce.salesforcedx-vscode-lwc'
+    // );
+    // expect(lwcExtensionWasFound).toBe(true);
 
     await utilities.pause(2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -177,7 +177,7 @@ export class TestSetup {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
-    utilities.pause(10);
+    await utilities.pause(10);
 
     // Verify CLI Integration extension is present and running
     const coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
@@ -235,12 +235,12 @@ export class TestSetup {
     );
     expect(lwcExtensionWasFound).toBe(true);
 
-    utilities.pause(2);
+    await utilities.pause(2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
-    utilities.pause(2);
+    await utilities.pause(2);
   }
 
   public async authorizeDevHub(): Promise<void> {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -42,7 +42,7 @@ export class TestSetup {
     utilities.log(`${this.testSuiteSuffixName} - Starting TestSetup.setUp()...`);
     await this.setUpTestingEnvironment();
     await this.createProject(scratchOrgEdition);
-    await this.verifyAllExtensionsAreRunning();
+    await utilities.verifyAllExtensionsAreRunning();
     await this.authorizeDevHub();
     await this.createDefaultScratchOrg();
     await this.disableCommandCenter();
@@ -183,81 +183,6 @@ export class TestSetup {
 
     utilities.log(`${this.testSuiteSuffixName} - ...finished createProject()`);
     utilities.log('');
-  }
-
-  public async verifyAllExtensionsAreRunning(): Promise<void> {
-    utilities.log('');
-    utilities.log(`${this.testSuiteSuffixName} - Starting verifyAllExtensionsAreRunning()...`);
-
-    // Using the Command palette, run Developer: Show Running Extensions
-    const workbench = await (await browser.getWorkbench()).wait();
-    await utilities.showRunningExtensions(workbench);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
-    await utilities.pause(10);
-
-    // Verify CLI Integration extension is present and running
-    const coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-core'
-    );
-    expect(coreExtensionWasFound).toBe(true);
-
-    // Verify Apex extension is present and running
-    const apexExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-apex'
-    );
-    expect(apexExtensionWasFound).toBe(true);
-
-    // Verify Apex Replay Debugger extension is present and running
-    const ardExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-apex-replay-debugger'
-    );
-    expect(ardExtensionWasFound).toBe(true);
-
-    // Verify Apex Interactive Debugger extension is present and running
-    const isvExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-apex-debugger'
-    );
-    expect(isvExtensionWasFound).toBe(true);
-
-    // Verify SOQL extension is present and running
-    const soqlExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-soql'
-    );
-    expect(soqlExtensionWasFound).toBe(true);
-
-    // Verify Aura extension is present and running
-    const auraExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-lightning'
-    );
-    expect(auraExtensionWasFound).toBe(true);
-
-    // Verify Visualforce extension is present and running
-    const vfExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-      workbench,
-      'salesforcedx-vscode-visualforce'
-    );
-    expect(vfExtensionWasFound).toBe(true);
-
-    // // Verify LWC extension is present and running
-    // const lwcExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
-    //   workbench,
-    //   'salesforcedx-vscode-lwc'
-    // );
-    // expect(lwcExtensionWasFound).toBe(true);
-
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
   }
 
   public async authorizeDevHub(): Promise<void> {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -254,12 +254,10 @@ export class TestSetup {
     // );
     // expect(lwcExtensionWasFound).toBe(true);
 
-    await utilities.pause(2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
-    await utilities.pause(2);
   }
 
   public async authorizeDevHub(): Promise<void> {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -83,6 +83,7 @@ export class TestSetup {
       3
     );
     await browser.keys(['Window: Command Center']);
+    await utilities.pause(3);
 
     const commandCenterBtn = await $('div[title="window.commandCenter"]');
     await commandCenterBtn.click();
@@ -134,7 +135,7 @@ export class TestSetup {
     // Do not continue until we verify CLI Integration extension is present and running
     let coreExtensionWasFound = false;
     do {
-      await utilities.pause(30);
+      await utilities.pause(10);
 
       coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
         workbench,

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -182,56 +182,56 @@ export class TestSetup {
     // Verify CLI Integration extension is present and running
     const coreExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-core'
+      'salesforcedx-vscode-core'
     );
     expect(coreExtensionWasFound).toBe(true);
 
     // Verify Apex extension is present and running
     const apexExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex'
+      'salesforcedx-vscode-apex'
     );
     expect(apexExtensionWasFound).toBe(true);
 
     // Verify Apex Replay Debugger extension is present and running
     const ardExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex-replay-debugger'
+      'salesforcedx-vscode-apex-replay-debugger'
     );
     expect(ardExtensionWasFound).toBe(true);
 
     // Verify Apex Interactive Debugger extension is present and running
     const isvExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex-debugger'
+      'salesforcedx-vscode-apex-debugger'
     );
     expect(isvExtensionWasFound).toBe(true);
 
     // Verify SOQL extension is present and running
     const soqlExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-soql'
+      'salesforcedx-vscode-soql'
     );
     expect(soqlExtensionWasFound).toBe(true);
 
     // Verify Aura extension is present and running
     const auraExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-lightning'
+      'salesforcedx-vscode-lightning'
     );
     expect(auraExtensionWasFound).toBe(true);
 
     // Verify Visualforce extension is present and running
     const vfExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-visualforce'
+      'salesforcedx-vscode-visualforce'
     );
     expect(vfExtensionWasFound).toBe(true);
 
     // // Verify LWC extension is present and running
     // const lwcExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
     //   workbench,
-    //   'salesforce.salesforcedx-vscode-lwc'
+    //   'salesforcedx-vscode-lwc'
     // );
     // expect(lwcExtensionWasFound).toBe(true);
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -151,7 +151,7 @@ export class TestSetup {
     // Selecting "SFDX: Create Project" causes the extension to be loaded, and this takes a while.
 
     // Select the "Standard" project type.
-    await utilities.selectQuickPickWithText(this.prompt, 'Standard');
+    await utilities.selectQuickPickItem(this.prompt, 'Standard');
 
     // Enter the project's name.
     await this.prompt.setText(this.tempProjectName);

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -196,7 +196,7 @@ export class TestSetup {
     // Verify Apex Replay Debugger extension is present and running
     const ardExtensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex-replay-debugger'
+      'salesforce.salesforcedx-vscode-apex-replay-debugge'
     );
     expect(ardExtensionWasFound).toBe(true);
 

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -8,7 +8,6 @@
 import { TextEditor } from 'wdio-vscode-service';
 import { runCommandFromCommandPrompt } from './commandPrompt';
 import { pause } from './miscellaneous';
-import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
 
 export async function createApexClass(
   name: string,
@@ -17,50 +16,22 @@ export async function createApexClass(
 ): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
 
-  // Replace the commented out code below with the keyboard commands
-
   // Using the Command palette, run SFDX: Create Apex Class to create the main class
-  await browser.keys([CMD_KEY, 'Shift', 'p']);
-  await pause(1);
-  await browser.keys(["SFDX: Create Apex Class"]);
-  await pause(1);
+  let inputBox = await runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Class', 1);
 
   // Set the name of the new Apex Class
-  await browser.keys([name]);
-  await pause(1);
-  await browser.keys(['Enter']);
-  await pause(1);
+  await inputBox.setText(name);
+  await inputBox.confirm();
 
   // Select the default directory (press Enter/Return).
-  await browser.keys(['Enter']);
+  await inputBox.confirm();
   await pause(1);
 
   // Modify class content
-  await browser.keys([CMD_KEY, 'p']);
+  inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+  await inputBox.setText(name + '.cls');
+  await inputBox.confirm();
   await pause(1);
-  await browser.keys([name]);
-  await pause(1);
-  await browser.keys([".cls"]);
-  await pause(1);
-  await browser.keys(['Enter']);
-  await pause(1);
-
-  // // Using the Command palette, run SFDX: Create Apex Class to create the main class
-  // let inputBox = await runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Class', 1);
-
-  // // Set the name of the new Apex Class
-  // await inputBox.setText(name);
-  // await inputBox.confirm();
-
-  // // Select the default directory (press Enter/Return).
-  // await inputBox.confirm();
-  // await pause(1);
-
-  // // Modify class content
-  // inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
-  // await inputBox.setText(name + '.cls');
-  // await inputBox.confirm();
-  // await pause(1);
 
   const editorView = workbench.getEditorView();
   const textEditor = (await editorView.openEditor(name + '.cls')) as TextEditor;

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -22,6 +22,7 @@ export async function createApexClass(
   // Set the name of the new Apex Class
   await inputBox.setText(name);
   await inputBox.confirm();
+  await pause(1);
 
   // Select the default directory (press Enter/Return).
   await inputBox.confirm();

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -21,16 +21,16 @@ export async function createApexClass(
 
   // Set the name of the new Apex Class
   await inputBox.setText(name);
-  await inputBox.confirm();
+  await browser.keys(['Enter']);
 
   // Select the default directory (press Enter/Return).
-  await inputBox.confirm();
+  await browser.keys(['Enter']);
   await pause(1);
 
   // Modify class content
   inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
   await inputBox.setText(name + '.cls');
-  await inputBox.confirm();
+  await browser.keys(['Enter']);
   await pause(1);
 
   const editorView = workbench.getEditorView();
@@ -116,8 +116,8 @@ export async function createAnonymousApexFile(): Promise<void> {
 
   // Set the name of the new Anonymous Apex file
   await inputBox.setText('Anonymous.apex');
-  await inputBox.confirm();
-  await inputBox.confirm();
+  await browser.keys(['Enter']);
+  await browser.keys(['Enter']);
 
   const textEditor = (await editorView.openEditor('Anonymous.apex')) as TextEditor;
   await textEditor.setText("System.debug('¡Hola mundo!');");

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -21,10 +21,10 @@ export async function createApexClass(
 
   // Set the name of the new Apex Class
   await inputBox.setText(name);
-  await browser.keys(['Enter']);
+  await inputBox.confirm();
 
   // Select the default directory (press Enter/Return).
-  await browser.keys(['Enter']);
+  await inputBox.confirm();
   await pause(1);
 
   // Modify class content

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -22,6 +22,8 @@ export async function createApexClass(
   // Using the Command palette, run SFDX: Create Apex Class to create the main class
   await browser.keys([CMD_KEY, 'Shift', 'p']);
   await pause(1);
+  await browser.keys(["SFDX: Create Apex Class"]);
+  await pause(1);
 
   // Set the name of the new Apex Class
   await browser.keys([name]);

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -21,11 +21,12 @@ export async function createApexClass(
 
   // Set the name of the new Apex Class
   await inputBox.setText(name);
-  await inputBox.confirm();
+  await pause(1);
+  await browser.keys(['Enter']);
   await pause(1);
 
   // Select the default directory (press Enter/Return).
-  await inputBox.confirm();
+  await browser.keys(['Enter']);
   await pause(1);
 
   // Modify class content

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -8,6 +8,7 @@
 import { TextEditor } from 'wdio-vscode-service';
 import { runCommandFromCommandPrompt } from './commandPrompt';
 import { pause } from './miscellaneous';
+import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
 
 export async function createApexClass(
   name: string,
@@ -16,22 +17,48 @@ export async function createApexClass(
 ): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
 
+  // Replace the commented out code below with the keyboard commands
+
   // Using the Command palette, run SFDX: Create Apex Class to create the main class
-  let inputBox = await runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Class', 1);
+  await browser.keys([CMD_KEY, 'Shift', 'p']);
+  await pause(1);
 
   // Set the name of the new Apex Class
-  await inputBox.setText(name);
-  await inputBox.confirm();
+  await browser.keys([name]);
+  await pause(1);
+  await browser.keys(['Enter']);
+  await pause(1);
 
   // Select the default directory (press Enter/Return).
-  await inputBox.confirm();
+  await browser.keys(['Enter']);
   await pause(1);
 
   // Modify class content
-  inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
-  await inputBox.setText(name + '.cls');
-  await inputBox.confirm();
+  await browser.keys([CMD_KEY, 'p']);
   await pause(1);
+  await browser.keys([name]);
+  await pause(1);
+  await browser.keys([".cls"]);
+  await pause(1);
+  await browser.keys(['Enter']);
+  await pause(1);
+
+  // // Using the Command palette, run SFDX: Create Apex Class to create the main class
+  // let inputBox = await runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Class', 1);
+
+  // // Set the name of the new Apex Class
+  // await inputBox.setText(name);
+  // await inputBox.confirm();
+
+  // // Select the default directory (press Enter/Return).
+  // await inputBox.confirm();
+  // await pause(1);
+
+  // // Modify class content
+  // inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+  // await inputBox.setText(name + '.cls');
+  // await inputBox.confirm();
+  // await pause(1);
 
   const editorView = workbench.getEditorView();
   const textEditor = (await editorView.openEditor(name + '.cls')) as TextEditor;

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -30,7 +30,7 @@ export async function createApexClass(
   // Modify class content
   inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
   await inputBox.setText(name + '.cls');
-  await browser.keys(['Enter']);
+  await inputBox.confirm();
   await pause(1);
 
   const editorView = workbench.getEditorView();

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -25,11 +25,10 @@ export async function runCommandFromCommandPrompt(
   durationInSeconds: number = 0
 ): Promise<InputBox | QuickOpenBox> {
   const prompt = await (await openCommandPromptWithCommand(workbench, command)).wait();
-  await pause(2);
-  await selectQuickPickItem(prompt, command);
+  await findQuickPickItem(prompt, command, false, true);
 
   if (durationInSeconds > 0) {
-    await pause(durationInSeconds - 2);
+    await pause(durationInSeconds);
   }
 
   return prompt;

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -25,10 +25,11 @@ export async function runCommandFromCommandPrompt(
   durationInSeconds: number = 0
 ): Promise<InputBox | QuickOpenBox> {
   const prompt = await (await openCommandPromptWithCommand(workbench, command)).wait();
+  await pause(2);
   await selectQuickPickItem(prompt, command);
 
   if (durationInSeconds > 0) {
-    await pause(durationInSeconds);
+    await pause(durationInSeconds - 2);
   }
 
   return prompt;

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -25,7 +25,7 @@ export async function runCommandFromCommandPrompt(
   durationInSeconds: number = 0
 ): Promise<InputBox | QuickOpenBox> {
   const prompt = await (await openCommandPromptWithCommand(workbench, command)).wait();
-  await findQuickPickItem(prompt, command, false, true);
+  await selectQuickPickItem(prompt, command);
 
   if (durationInSeconds > 0) {
     await pause(durationInSeconds);
@@ -51,6 +51,12 @@ export async function selectQuickPickItem(
   prompt: InputBox | QuickOpenBox,
   text: string
 ): Promise<void> {
+
+  // Type the text into the filter.  Do this in case the pick list is long and
+  // the target item is not visible (and one needs to scroll down to see it).
+  await prompt.setText(text);
+  await pause(1);
+
   const quickPicks = await prompt.getQuickPicks();
   for (const quickPick of quickPicks) {
     const label = await quickPick.getLabel();

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -52,6 +52,9 @@ export async function selectQuickPickItem(
   text: string
 ): Promise<void> {
 
+  log('--- enter selectQuickPickItem()');
+  log('--- text = ' + text);
+
   const quickPicks = await prompt.getQuickPicks();
   log('!!! quickPicks = ' + quickPicks);
   for (const quickPick of quickPicks) {
@@ -60,6 +63,7 @@ export async function selectQuickPickItem(
     if (label === text) {
       log('&&& Command Found!');
       await quickPick.select();
+      log ('&&& quick pick selected');
       return;
     }
   }

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -52,18 +52,11 @@ export async function selectQuickPickItem(
   text: string
 ): Promise<void> {
 
-  log('--- enter selectQuickPickItem()');
-  log('--- text = ' + text);
-
   const quickPicks = await prompt.getQuickPicks();
-  log('!!! quickPicks = ' + quickPicks);
   for (const quickPick of quickPicks) {
     const label = await quickPick.getLabel();
-    log('*** label = ' + label);
     if (label === text) {
-      log('&&& Command Found!');
       await quickPick.select();
-      log ('&&& quick pick selected');
       return;
     }
   }

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -25,7 +25,7 @@ export async function runCommandFromCommandPrompt(
   durationInSeconds: number = 0
 ): Promise<InputBox | QuickOpenBox> {
   const prompt = await (await openCommandPromptWithCommand(workbench, command)).wait();
-  await selectQuickPickItem(prompt, command);
+  await selectQuickPickWithText(prompt, command);
 
   if (durationInSeconds > 0) {
     await pause(durationInSeconds);
@@ -51,11 +51,6 @@ export async function selectQuickPickItem(
   prompt: InputBox | QuickOpenBox,
   text: string
 ): Promise<void> {
-
-  // Type the text into the filter.  Do this in case the pick list is long and
-  // the target item is not visible (and one needs to scroll down to see it).
-  await prompt.setText(text);
-  await pause(1);
 
   const quickPicks = await prompt.getQuickPicks();
   for (const quickPick of quickPicks) {

--- a/test/utilities/commandPrompt.ts
+++ b/test/utilities/commandPrompt.ts
@@ -25,7 +25,7 @@ export async function runCommandFromCommandPrompt(
   durationInSeconds: number = 0
 ): Promise<InputBox | QuickOpenBox> {
   const prompt = await (await openCommandPromptWithCommand(workbench, command)).wait();
-  await selectQuickPickWithText(prompt, command);
+  await selectQuickPickItem(prompt, command);
 
   if (durationInSeconds > 0) {
     await pause(durationInSeconds);
@@ -53,9 +53,12 @@ export async function selectQuickPickItem(
 ): Promise<void> {
 
   const quickPicks = await prompt.getQuickPicks();
+  log('!!! quickPicks = ' + quickPicks);
   for (const quickPick of quickPicks) {
     const label = await quickPick.getLabel();
+    log('*** label = ' + label);
     if (label === text) {
+      log('&&& Command Found!');
       await quickPick.select();
       return;
     }

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -7,7 +7,7 @@
 
 import { Workbench } from 'wdio-vscode-service';
 import { runCommandFromCommandPrompt } from './commandPrompt';
-import { pause } from './miscellaneous';
+import { pause, log } from './miscellaneous';
 
 export async function showRunningExtensions(workbench: Workbench): Promise<void> {
   await runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
@@ -20,7 +20,12 @@ export async function findExtensionInRunningExtensionsList(
   // This function assumes the Extensions list was opened.
 
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
-  await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
+  try {
+    await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
+  }
+  catch {
+    log('No panel to close - command not found');
+  }
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
   const extensionNameDivs = await $$('div.name');

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -28,6 +28,7 @@ export async function findExtensionInRunningExtensionsList(
     await browser.keys(['Escape']);
     log('No panel to close - command not found');
   }
+  pause(1);
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
   const extensionNameDivs = await $$('div.monaco-list-row');

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -42,3 +42,78 @@ export async function findExtensionInRunningExtensionsList(
 
   return extensionWasFound;
 }
+
+export async function verifyAllExtensionsAreRunning(): Promise<void> {
+  log('');
+  log(`Starting verifyAllExtensionsAreRunning()...`);
+
+  // Using the Command palette, run Developer: Show Running Extensions
+  const workbench = await (await browser.getWorkbench()).wait();
+  await showRunningExtensions(workbench);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 2);
+  await pause(10);
+
+  // Verify CLI Integration extension is present and running
+  const coreExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-core'
+  );
+  expect(coreExtensionWasFound).toBe(true);
+
+  // Verify Apex extension is present and running
+  const apexExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-apex'
+  );
+  expect(apexExtensionWasFound).toBe(true);
+
+  // Verify Apex Replay Debugger extension is present and running
+  const ardExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-apex-replay-debugger'
+  );
+  expect(ardExtensionWasFound).toBe(true);
+
+  // Verify Apex Interactive Debugger extension is present and running
+  const isvExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-apex-debugger'
+  );
+  expect(isvExtensionWasFound).toBe(true);
+
+  // Verify SOQL extension is present and running
+  const soqlExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-soql'
+  );
+  expect(soqlExtensionWasFound).toBe(true);
+
+  // Verify Aura extension is present and running
+  const auraExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-lightning'
+  );
+  expect(auraExtensionWasFound).toBe(true);
+
+  // Verify Visualforce extension is present and running
+  const vfExtensionWasFound = await findExtensionInRunningExtensionsList(
+    workbench,
+    'salesforcedx-vscode-visualforce'
+  );
+  expect(vfExtensionWasFound).toBe(true);
+
+  // // Verify LWC extension is present and running
+  // const lwcExtensionWasFound = await findExtensionInRunningExtensionsList(
+  //   workbench,
+  //   'salesforcedx-vscode-lwc'
+  // );
+  // expect(lwcExtensionWasFound).toBe(true);
+
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+  await runCommandFromCommandPrompt(workbench, 'View: Zoom In', 2);
+}

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -24,6 +24,8 @@ export async function findExtensionInRunningExtensionsList(
     await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
   }
   catch {
+    // Close the command prompt by hitting the Escape key
+    await browser.keys(['Escape']);
     log('No panel to close - command not found');
   }
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -20,6 +20,7 @@ export async function findExtensionInRunningExtensionsList(
   // This function assumes the Extensions list was opened.
 
   await browser.keys(['Escape']);
+  await pause(1);
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
   try {
     await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
@@ -27,9 +28,11 @@ export async function findExtensionInRunningExtensionsList(
   catch {
     // Close the command prompt by hitting the Escape key
     await browser.keys(['Escape']);
+    await pause(1);
     log('No panel to close - command not found');
   }
   await browser.keys(['Escape']);
+  await pause(1);
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
   const extensionNameDivs = await $$('div.monaco-list-row');

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -19,6 +19,7 @@ export async function findExtensionInRunningExtensionsList(
 ): Promise<boolean> {
   // This function assumes the Extensions list was opened.
 
+  await browser.keys(['Escape']);
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
   try {
     await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
@@ -28,6 +29,7 @@ export async function findExtensionInRunningExtensionsList(
     await browser.keys(['Escape']);
     log('No panel to close - command not found');
   }
+  await browser.keys(['Escape']);
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
   const extensionNameDivs = await $$('div.monaco-list-row');

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -30,10 +30,10 @@ export async function findExtensionInRunningExtensionsList(
   }
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
-  const extensionNameDivs = await $$('div.name');
+  const extensionNameDivs = await $$('div.monaco-list-row');
   let extensionWasFound = false;
   for (const extensionNameDiv of extensionNameDivs) {
-    const text = await extensionNameDiv.getText();
+    const text = await extensionNameDiv.getAttribute('aria-label');
     if (text.includes(extensionName)) {
       extensionWasFound = true;
     }

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -19,8 +19,6 @@ export async function findExtensionInRunningExtensionsList(
 ): Promise<boolean> {
   // This function assumes the Extensions list was opened.
 
-  await browser.keys(['Escape']);
-  await pause(1);
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
   try {
     await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
@@ -28,11 +26,8 @@ export async function findExtensionInRunningExtensionsList(
   catch {
     // Close the command prompt by hitting the Escape key
     await browser.keys(['Escape']);
-    await pause(1);
     log('No panel to close - command not found');
   }
-  await browser.keys(['Escape']);
-  await pause(1);
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
   const extensionNameDivs = await $$('div.monaco-list-row');


### PR DESCRIPTION
This PR contains fixes for the most common setup errors that are causing E2E tests to fail.  Here is what got fixed:

1. **Problem**: "element not interactable" when running "SFDX: Create Project" to start each E2E test because the CLI Integration extension is not yet loaded.
**Solution**: Run "SFDX: Create Project" to trigger the CLI Integration extension to load, then hit Escape and check every 10 seconds that the extension is actually loaded.  After the extension is activated, run "SFDX: Create Project" again to completion.

2. **Problem**: "Quick Pick Item SFDX: ______ was not found" after running "Developer: Reload Window".
**Solution**: Every time "Developer: Reload Window" is run, wait for all extensions to start up and confirm that they are activated before they are called.

3. **Problem**: When switching to a different tab the Editor View, the tab is sometimes hidden to the right side because the VSCode window is too small.
**Solution**: Use "Go to File" in the command palette to open the file or switch to that tab instead of searching the visible tabs for the file name.

4. **Problem**: "element not interactable" when trying to click the 'Clear Output' button in the Output panel.
**Solution**: Use the command palette "View: Clear Output" instead of clicking the 'Clear Output' button.

5. **Problem**: Cannot click the "Prefer Deploy on Save" button in Settings because it is hidden by the Output panel when the VSCode window is too small.
**Solution**: Run "View: Close Panel" to make the setting visible on the page before clicking the checkbox.

This PR also contains a new helper function in extensionUtils.ts called verifyAllExtensionsAreRunning().  This helper function is used in testSetup.ts, after "Developer: Reload Window" (see Problem 2 above), and in a refactor of AnInitialSuite.e2e.ts to improve the verification of running extensions.

@W-14202398@