### PR TITLE
chore: refactor findExtensionInRunningExtensionsList

### DIFF
--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -34,7 +34,7 @@ describe('Apex LSP', async () => {
     // Verify Apex extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-apex'
+      'salesforcedx-vscode-apex'
     );
     expect(extensionWasFound).toBe(true);
   });

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -33,7 +33,7 @@ describe('Aura LSP', async () => {
     // Verify Aura Components extension is present and running.
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-lightning'
+      'salesforcedx-vscode-lightning'
     );
     expect(extensionWasFound).toBe(true);
   });
@@ -48,7 +48,7 @@ describe('Aura LSP', async () => {
     // Move cursor to the middle of "simpleNewContact"
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
-    await browser.keys(["!v.sim"]);
+    await browser.keys(['!v.sim']);
     await browser.keys(['Escape']);
     await browser.keys(['ArrowRight']);
     await utilities.pause(1);

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -22,9 +22,7 @@ describe('LWC LSP', async () => {
   });
 
   step('Verify Extension is Running', async () => {
-    utilities.log(
-      `${testSetup.testSuiteSuffixName} - Verify Extension is Running`
-    );
+    utilities.log(`${testSetup.testSuiteSuffixName} - Verify Extension is Running`);
 
     // Using the Command palette, run Developer: Show Running Extensions
     const workbench = await browser.getWorkbench();
@@ -32,14 +30,15 @@ describe('LWC LSP', async () => {
     await utilities.enableLwcExtension();
 
     // Verify Lightning Web Components extension is present and running
-    const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(workbench, 'salesforce.salesforcedx-vscode-lwc');
+    const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
+      workbench,
+      'salesforcedx-vscode-lwc'
+    );
     expect(extensionWasFound).toBe(true);
   });
 
   step('Go to Definition (JavaScript)', async () => {
-    utilities.log(
-      `${testSetup.testSuiteSuffixName} - Go to Definition (Javascript)`
-    );
+    utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition (Javascript)`);
     // Get open text editor
     const workbench = await browser.getWorkbench();
     const editorView = workbench.getEditorView();
@@ -84,15 +83,9 @@ describe('LWC LSP', async () => {
     await utilities.pause(2);
 
     // Verify autocompletion options are present
-    const autocompletionOptions = await $$(
-      'textarea.inputarea.monaco-mouse-cursor-text'
-    );
-    expect(await autocompletionOptions[0].getAttribute('aria-haspopup')).toBe(
-      'true'
-    );
-    expect(
-      await autocompletionOptions[0].getAttribute('aria-autocomplete')
-    ).toBe('list');
+    const autocompletionOptions = await $$('textarea.inputarea.monaco-mouse-cursor-text');
+    expect(await autocompletionOptions[0].getAttribute('aria-haspopup')).toBe('true');
+    expect(await autocompletionOptions[0].getAttribute('aria-autocomplete')).toBe('list');
 
     // Verify autocompletion options can be selected and therefore automatically inserted into the file
     await browser.keys(['Enter']);

--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -73,7 +73,7 @@ describe('Visualforce LSP', async () => {
     // Verify Visualforce extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
       workbench,
-      'salesforce.salesforcedx-vscode-visualforce'
+      'salesforcedx-vscode-visualforce'
     );
     expect(extensionWasFound).toBe(true);
   });

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -7,7 +7,7 @@
 
 import { Workbench } from 'wdio-vscode-service';
 import { runCommandFromCommandPrompt } from './commandPrompt';
-import { pause } from './miscellaneous';
+import { log, pause } from './miscellaneous';
 
 export async function showRunningExtensions(workbench: Workbench): Promise<void> {
   await runCommandFromCommandPrompt(workbench, 'Developer: Show Running Extensions', 5);
@@ -20,13 +20,20 @@ export async function findExtensionInRunningExtensionsList(
   // This function assumes the Extensions list was opened.
 
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
-  await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
+  try {
+    await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
+  } catch {
+    // Close the command prompt by hitting the Escape key
+    await browser.keys(['Escape']);
+    log('No panel to close - command not found');
+  }
+  pause(1);
   await runCommandFromCommandPrompt(workbench, 'Notifications: Clear All Notifications', 1);
 
-  const extensionNameDivs = await $$('div.name');
+  const extensionNameDivs = await $$('div.monaco-list-row');
   let extensionWasFound = false;
   for (const extensionNameDiv of extensionNameDivs) {
-    const text = await extensionNameDiv.getText();
+    const text = await extensionNameDiv.getAttribute('aria-label');
     if (text.includes(extensionName)) {
       extensionWasFound = true;
     }


### PR DESCRIPTION
This is just a refactor of `findExtensionInRunningExtensionsList()` in order to check for the right id in the html and not what's displayed