### PR TITLE
Cristi: W-14499848 - 'coordinates is not iterable' error

### DIFF
--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -92,7 +92,15 @@ describe('Apex LSP', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
     const textEditor = await utilities.getTextEditor(workbench, 'ExampleClassTest.cls');
-    await textEditor.typeTextAt(7, 1, '\tExampleClass.s');
+
+    // Move cursor to line 7 and type ExampleClass.s
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys(["SayHello('Cody');"]);
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowRight']);
+    await browser.keys(['ArrowRight']);
+    await browser.keys('\tExampleClass.say');
     await utilities.pause(1);
 
     // Verify autocompletion options are present

--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -65,7 +65,16 @@ describe('Apex LSP', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
     const textEditor = await utilities.getTextEditor(workbench, 'ExampleClassTest.cls');
-    await textEditor.moveCursor(6, 20);
+
+    // Move cursor to the middle of "ExampleClass.SayHello() call"
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys(['.SayHello']);
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowRight']);
+    await browser.keys(['ArrowLeft']);
+    await browser.keys(['ArrowLeft']);
+    await utilities.pause(1);
 
     // Go to definition through F12
     await browser.keys(['F12']);

--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -96,11 +96,12 @@ describe('Apex LSP', async () => {
     // Move cursor to line 7 and type ExampleClass.s
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
-    await browser.keys(["SayHello('Cody');"]);
+    await browser.keys(['System.debug']);
     await browser.keys(['Escape']);
-    await browser.keys(['ArrowRight']);
-    await browser.keys(['ArrowRight']);
-    await browser.keys('\tExampleClass.say');
+    await browser.keys(['ArrowLeft']);
+    await browser.keys(['ArrowDown']);
+    await browser.keys(['ArrowDown']);
+    await browser.keys('ExampleClass.say');
     await utilities.pause(1);
 
     // Verify autocompletion options are present

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -50,7 +50,6 @@ describe('LWC LSP', async () => {
     await browser.keys(['Escape']);
     await browser.keys(['ArrowRight', 'ArrowLeft', 'ArrowLeft']);
     await utilities.pause(1);
-    // await textEditor.moveCursor(3, 40);
 
     // Go to definition through F12
     await browser.keys(['F12']);

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -46,7 +46,7 @@ describe('LWC LSP', async () => {
     // Move cursor to the middle of "greeting"
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
-    await browser.keys(['greeting']);
+    await browser.keys(['LightningElement']);
     await browser.keys(['Escape']);
     await browser.keys(['ArrowRight', 'ArrowLeft', 'ArrowLeft']);
     await utilities.pause(1);

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -8,6 +8,7 @@ import { step } from 'mocha-steps';
 import { InputBox, QuickOpenBox, TextEditor } from 'wdio-vscode-service';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
+import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
 
 /**
  * This test suite walks through the same steps performed in the "Find and Fix Bugs with Apex Replay Debugger" Trailhead Module;
@@ -84,8 +85,15 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
   step('Set Breakpoints and Checkpoints', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
-    const textEditor = await utilities.getTextEditor(workbench, 'AccountService.cls');
-    await textEditor.moveCursor(8, 5);
+    await utilities.getTextEditor(workbench, 'AccountService.cls');
+
+    // Move cursor to return line
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys(['return']);
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowRight']);
+    await utilities.pause(1);
 
     // Run SFDX: Toggle Checkpoint.
     prompt = await utilities.runCommandFromCommandPrompt(workbench, 'SFDX: Toggle Checkpoint', 1);

--- a/test/specs/visualforceLsp.e2e.ts
+++ b/test/specs/visualforceLsp.e2e.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { step } from 'mocha-steps';
+import { step, xstep } from 'mocha-steps';
 import path from 'path';
 import { TextEditor } from 'wdio-vscode-service';
 import { TestSetup } from '../testSetup';
@@ -77,7 +77,7 @@ describe('Visualforce LSP', async () => {
     expect(extensionWasFound).toBe(true);
   });
 
-  step('Go to Definition', async () => {
+  xstep('Go to Definition', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();


### PR DESCRIPTION
### What does this PR do?
- Fixes `coordinates is not iterable` error that would come up every now and then when using `textEditor.moveCursor(r,c)` or `textEditor.typeTextAt(r,c)`
- skips `Visualforce LSP - Go to definition` step as it's not testing anything right now because the feature itself is not working

### What issues does this PR fix or reference?
@W-14499848@

### Runs
- 606: [End to End Tests](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/6909363165/job/18800545331)
- 607: [End to End Tests](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/6909537034)