### PR TITLE
E2E test improvements - (1) fix for "coordinates is not iterable" error in LWC LSP (2) SFDX -> SF

### DIFF
--- a/test/setup/anInitialSetUp.e2e.ts
+++ b/test/setup/anInitialSetUp.e2e.ts
@@ -38,12 +38,12 @@ describe('An Initial SetUp', async () => {
 
     // For sfdx -> sf, remove the two lines below this comment block and uncomment the following line instead
     // await exec(`sf org login sfdx-url --sfdx-url-file ${authFilePath} --set-default --alias ${devHubAliasName}`);
-    const authorizeOrg = await exec(`sfdx auth:sfdxurl:store -d -f ${authFilePath}`);
+    const authorizeOrg = await exec(`sfdx org:login:sfdx-url -d -f ${authFilePath}`);
     expect(authorizeOrg.stdout).toContain(
       `Successfully authorized ${devHubUserName} with org ID ${orgId}`
     );
 
-    const setAlias = await exec(`sfdx alias set ${devHubAliasName}=${devHubUserName}`);
+    const setAlias = await exec(`sfdx alias:set ${devHubAliasName}=${devHubUserName}`);
     expect(setAlias.stdout).toContain(devHubAliasName);
     expect(setAlias.stdout).toContain(devHubUserName);
     expect(setAlias.stdout).toContain('true');

--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -80,7 +80,7 @@ describe('Apex LSP', async () => {
     await utilities.pause(1);
 
     // Verify 'Go to definition' took us to the definition file
-    const editorView = await workbench.getEditorView();
+    const editorView = workbench.getEditorView();
     const activeTab = await editorView.getActiveTab();
     const title = await activeTab?.getTitle();
     expect(title).toBe('ExampleClass.cls');

--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -180,7 +180,7 @@ describe('Apex Replay Debugger', async () => {
   step('SFDX: Launch Apex Replay Debugger with Last Log File', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
-    const editorView = await workbench.getEditorView();
+    const editorView = workbench.getEditorView();
 
     // Get file path from open text editor
     const activeTab = await editorView.getActiveTab();

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -96,7 +96,6 @@ describe('LWC LSP', async () => {
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
     await browser.keys(['div']);
-    await browser.keys(['Enter']);
     await browser.keys(['Escape']);
     await browser.keys(['ArrowRight']);
     await utilities.pause(1);

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -70,9 +70,7 @@ describe('LWC LSP', async () => {
     // Move cursor to the middle of "greeting"
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
-    await browser.keys(['greeting']);
-    await browser.keys(['Escape']);
-    await browser.keys(['ArrowRight', 'ArrowLeft', 'ArrowLeft']);
+    await browser.keys(['greeting','Escape','ArrowRight', 'ArrowLeft', 'ArrowLeft']);
     await utilities.pause(1);
 
     // Go to definition through F12

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -70,7 +70,7 @@ describe('LWC LSP', async () => {
     // Move cursor to the middle of "greeting"
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
-    await browser.keys(['greeting','Escape','ArrowRight', 'ArrowLeft', 'ArrowLeft']);
+    await browser.keys(['greeting', 'Escape', 'ArrowRight', 'ArrowLeft', 'ArrowLeft']);
     await utilities.pause(1);
 
     // Go to definition through F12
@@ -93,9 +93,7 @@ describe('LWC LSP', async () => {
     // Move cursor to right after the first 'div' tag and type ' lwc'
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
-    await browser.keys(['div']);
-    await browser.keys(['Escape']);
-    await browser.keys(['ArrowRight']);
+    await browser.keys(['div', 'Escape', 'ArrowRight']);
     await utilities.pause(1);
     await browser.keys([' lwc']);
     await utilities.pause(2);

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -91,7 +91,16 @@ describe('LWC LSP', async () => {
     // Get open text editor
     const workbench = await browser.getWorkbench();
     const textEditor = await utilities.getTextEditor(workbench, 'lwc1.html');
-    await textEditor.typeTextAt(3, 7, ' lwc');
+
+    // Move cursor to an empty space and type "lwc"
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys(['div']);
+    await browser.keys(['Enter']);
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+    await utilities.pause(1);
+    await browser.keys(['lwc']);
     await utilities.pause(2);
 
     // Verify autocompletion options are present

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -42,7 +42,7 @@ describe('LWC LSP', async () => {
     const workbench = await browser.getWorkbench();
     await utilities.getTextEditor(workbench, 'lwc1.js');
 
-    // Move cursor to the middle of "greeting"
+    // Move cursor to the middle of "LightningElement"
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
     await browser.keys(['LightningElement']);
@@ -55,7 +55,7 @@ describe('LWC LSP', async () => {
     await utilities.pause(1);
 
     // Verify 'Go to definition' took us to the definition file
-    const editorView = await workbench.getEditorView();
+    const editorView = workbench.getEditorView();
     const activeTab = await editorView.getActiveTab();
     const title = await activeTab?.getTitle();
     expect(title).toBe('engine.d.ts');
@@ -65,15 +65,22 @@ describe('LWC LSP', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition (HTML)`);
     // Get open text editor
     const workbench = await browser.getWorkbench();
-    const textEditor = await utilities.getTextEditor(workbench, 'lwc1.html');
-    await textEditor.moveCursor(3, 52);
+    await utilities.getTextEditor(workbench, 'lwc1.html');
+
+    // Move cursor to the middle of "greeting"
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys(['greeting']);
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowRight', 'ArrowLeft', 'ArrowLeft']);
+    await utilities.pause(1);
 
     // Go to definition through F12
     await browser.keys(['F12']);
     await utilities.pause(1);
 
     // Verify 'Go to definition' took us to the definition file
-    const editorView = await workbench.getEditorView();
+    const editorView = workbench.getEditorView();
     const activeTab = await editorView.getActiveTab();
     const title = await activeTab?.getTitle();
     expect(title).toBe('lwc1.js');

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -98,9 +98,9 @@ describe('LWC LSP', async () => {
     await browser.keys(['div']);
     await browser.keys(['Enter']);
     await browser.keys(['Escape']);
-    await browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+    await browser.keys(['ArrowRight']);
     await utilities.pause(1);
-    await browser.keys(['lwc']);
+    await browser.keys([' lwc']);
     await utilities.pause(2);
 
     // Verify autocompletion options are present

--- a/test/specs/lwcLsp.e2e.ts
+++ b/test/specs/lwcLsp.e2e.ts
@@ -92,7 +92,7 @@ describe('LWC LSP', async () => {
     const workbench = await browser.getWorkbench();
     const textEditor = await utilities.getTextEditor(workbench, 'lwc1.html');
 
-    // Move cursor to an empty space and type "lwc"
+    // Move cursor to right after the first 'div' tag and type ' lwc'
     await browser.keys([CMD_KEY, 'f']);
     await utilities.pause(1);
     await browser.keys(['div']);

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -311,7 +311,7 @@ describe('Push and Pull', async () => {
     fs.writeFileSync(systemAdminUserDefPath, JSON.stringify(systemAdminUserDef), 'utf8');
 
     const sfdxForceOrgCreateResult = await exec(
-      `sfdx org:create:user --definition-file ${systemAdminUserDefPath}`
+      `sfdx org:create:user --definition-file ${systemAdminUserDefPath} --target-org ${testSetup.scratchOrgAliasName}`
     );
     expect(sfdxForceOrgCreateResult.stdout).toContain(
       `Successfully created user "${adminEmailAddress}"`

--- a/test/specs/pushAndPull.e2e.ts
+++ b/test/specs/pushAndPull.e2e.ts
@@ -311,7 +311,7 @@ describe('Push and Pull', async () => {
     fs.writeFileSync(systemAdminUserDefPath, JSON.stringify(systemAdminUserDef), 'utf8');
 
     const sfdxForceOrgCreateResult = await exec(
-      `sfdx force:user:create --definitionfile ${systemAdminUserDefPath}`
+      `sfdx org:create:user --definition-file ${systemAdminUserDefPath}`
     );
     expect(sfdxForceOrgCreateResult.stdout).toContain(
       `Successfully created user "${adminEmailAddress}"`

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -327,7 +327,7 @@ export class TestSetup {
 
     utilities.log(`${this.testSuiteSuffixName} - calling "sfdx org:create:scratch"...`);
     const sfdxForceOrgCreateResult = await exec(
-      `sfdx org:create:scratch --edition developer --definition-file ${definitionFile} --alias ${this.scratchOrgAliasName} --duration-days ${durationDays} --json`
+      `sfdx org:create:scratch --edition developer --definition-file ${definitionFile} --alias ${this.scratchOrgAliasName} --duration-days ${durationDays} --set-default --json`
     );
     utilities.log(`${this.testSuiteSuffixName} - ..."sfdx org:create:scratch" finished`);
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -215,9 +215,9 @@ export class TestSetup {
     fs.writeFileSync(authFilePath, json);
     utilities.log(`${this.testSuiteSuffixName} - finished writing the file...`);
 
-    // Call auth:sfdxurl:store and read in the JSON that was just created.
-    utilities.log(`${this.testSuiteSuffixName} - calling sfdx auth:sfdxurl:store...`);
-    const sfdxSfdxUrlStoreResult = await exec(`sfdx auth:sfdxurl:store -d -f ${authFilePath}`);
+    // Call org:login:sfdx-url and read in the JSON that was just created.
+    utilities.log(`${this.testSuiteSuffixName} - calling sfdx org:login:sfdx-url...`);
+    const sfdxSfdxUrlStoreResult = await exec(`sfdx org:login:sfdx-url -d -f ${authFilePath}`);
     if (
       !sfdxSfdxUrlStoreResult.stdout.includes(
         `Successfully authorized ${EnvironmentSettings.getInstance().devHubUserName} with org ID`

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -60,7 +60,7 @@ export class TestSetup {
       // await utilities.executeCommand(workbench, `sfdx force:org:delete -u ${this.scratchOrgAliasName} --noprompt`);
 
       // The Terminal view can be a bit unreliable, so directly call exec() instead:
-      await exec(`sfdx force:org:delete -u ${this.scratchOrgAliasName} --noprompt`);
+      await exec(`sfdx org:scratch:delete --target-org ${this.scratchOrgAliasName} --no-prompt`);
     }
 
     // This used to work...
@@ -203,9 +203,9 @@ export class TestSetup {
 
     // This is essentially the "SFDX: Authorize a Dev Hub" command, but using the CLI and an auth file instead of the UI.
     const authFilePath = path.join(this.projectFolderPath!, 'authFile.json');
-    utilities.log(`${this.testSuiteSuffixName} - calling sfdx force:org:display...`);
+    utilities.log(`${this.testSuiteSuffixName} - calling sfdx org:display...`);
     const sfdxForceOrgDisplayResult = await exec(
-      `sfdx force:org:display -u ${
+      `sfdx org:display --target-org ${
         EnvironmentSettings.getInstance().devHubAliasName
       } --verbose --json`
     );

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -327,7 +327,7 @@ export class TestSetup {
 
     utilities.log(`${this.testSuiteSuffixName} - calling "sfdx org:create:scratch"...`);
     const sfdxForceOrgCreateResult = await exec(
-      `sfdx org:create:scratch -f ${definitionFile} --setalias ${this.scratchOrgAliasName} --durationdays ${durationDays} --setdefaultusername --json --loglevel fatal`
+      `sfdx org:create:scratch --edition developer --definition-file ${definitionFile} --alias ${this.scratchOrgAliasName} --duration-days ${durationDays} --json`
     );
     utilities.log(`${this.testSuiteSuffixName} - ..."sfdx org:create:scratch" finished`);
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -60,7 +60,7 @@ export class TestSetup {
       // await utilities.executeCommand(workbench, `sfdx force:org:delete -u ${this.scratchOrgAliasName} --noprompt`);
 
       // The Terminal view can be a bit unreliable, so directly call exec() instead:
-      await exec(`sfdx org:scratch:delete --target-org ${this.scratchOrgAliasName} --no-prompt`);
+      await exec(`sfdx org:delete:scratch --target-org ${this.scratchOrgAliasName} --no-prompt`);
     }
 
     // This used to work...

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -325,11 +325,11 @@ export class TestSetup {
     const startDate = Date.now();
     const durationDays = 1;
 
-    utilities.log(`${this.testSuiteSuffixName} - calling "sfdx force:org:create"...`);
+    utilities.log(`${this.testSuiteSuffixName} - calling "sfdx org:create:scratch"...`);
     const sfdxForceOrgCreateResult = await exec(
-      `sfdx force:org:create -f ${definitionFile} --setalias ${this.scratchOrgAliasName} --durationdays ${durationDays} --setdefaultusername --json --loglevel fatal`
+      `sfdx org:create:scratch -f ${definitionFile} --setalias ${this.scratchOrgAliasName} --durationdays ${durationDays} --setdefaultusername --json --loglevel fatal`
     );
-    utilities.log(`${this.testSuiteSuffixName} - ..."sfdx force:org:create" finished`);
+    utilities.log(`${this.testSuiteSuffixName} - ..."sfdx org:create:scratch" finished`);
 
     utilities.log(`${this.testSuiteSuffixName} - calling removedEscapedCharacters()...`);
     const json = this.removedEscapedCharacters(sfdxForceOrgCreateResult.stdout);

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -249,7 +249,7 @@ export class TestSetup {
       throw new Error('Error: devHubUserName was not set.');
     }
 
-    const execResult = await exec('sfdx org list --json');
+    const execResult = await exec('sfdx org:list --json');
     const sfdxForceOrgListJson = this.removedEscapedCharacters(execResult.stdout);
     const sfdxForceOrgListResult = JSON.parse(sfdxForceOrgListJson).result;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -280,7 +280,7 @@ export class TestSetup {
     if (this.reuseScratchOrg) {
       utilities.log(`${this.testSuiteSuffixName} - looking for a scratch org to reuse...`);
 
-      const sfdxForceOrgListResult = await exec('sfdx force:org:list --json');
+      const sfdxForceOrgListResult = await exec('sfdx org:list --json');
       const resultJson = sfdxForceOrgListResult.stdout
         .replace(/\u001B\[\d\dm/g, '')
         .replace(/\\n/g, '');

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -55,27 +55,9 @@ export class TestSetup {
 
   public async tearDown(): Promise<void> {
     if (this.scratchOrgAliasName && !this.reuseScratchOrg) {
-      // To use VS Code's Terminal view to delete the scratch org, use:
-      // const workbench = await (await browser.getWorkbench()).wait();
-      // await utilities.executeCommand(workbench, `sfdx force:org:delete -u ${this.scratchOrgAliasName} --noprompt`);
-
       // The Terminal view can be a bit unreliable, so directly call exec() instead:
       await exec(`sfdx org:delete:scratch --target-org ${this.scratchOrgAliasName} --no-prompt`);
     }
-
-    // This used to work...
-    // if (this.projectFolderPath) {
-    //   await utilities.removeFolder(this.projectFolderPath);
-    // }
-    // ...but something recently changed and now, removing the folder while VS Code has the folder open
-    // causes VS Code to get into a funky state.  The next time a project is created, we get the
-    // following error:
-    //   07:45:19.65 Starting SFDX: Create Project
-    //   ENOENT: no such file or directory, uv_cwd
-    //
-    // Not deleting the folder that was created is OK, b/c it is deleted in setUpTestingEnvironment()
-    // the next time the test suite runs.  I'm going to leave this in for now in case this gets fixed
-    // and this code can be added back in.
   }
 
   public async disableCommandCenter(): Promise<void> {

--- a/test/utilities/miscellaneous.ts
+++ b/test/utilities/miscellaneous.ts
@@ -99,7 +99,7 @@ export async function getTextEditor(workbench: Workbench, fileName: string): Pro
   await inputBox.setText(fileName);
   await inputBox.confirm();
   await pause(1);
-  const editorView = await workbench.getEditorView();
+  const editorView = workbench.getEditorView();
   const textEditor = (await editorView.openEditor(fileName)) as TextEditor;
   return textEditor;
 }


### PR DESCRIPTION
This PR contains two main improvements to the E2E tests:
1. Previously, we were seeing a "coordinates is not iterable" error in about 80% of our Ubuntu test runs of the LWC LSP E2E test.  This PR replaces the `.typeTextAt()` function with `browser.keys` in order to work around that issue.
2. In our code, several CLI commands are called using `exec()` to be run directly in the Terminal.  The following CLI commands are changed from SFDX-style to SF-style:
a. `auth:sfdxurl:store` -> `org:login:sfdx-url`
b. `force:user:create` -> `org:create:user`
c. `force:org:delete` -> `org:delete:scratch`
d. `force:org:display` -> `org:display`
e. `force:org:list` -> `org:list`
f. `force:org:create` -> `org:create:scratch`

Passing E2E test run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7474955893

@W-14791862@
@W-14791836@