### PR TITLE
fix: change command name to 'SFDX: Push Source to Default Org and Ignore Conflicts'

### DIFF
--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -26,13 +26,13 @@ describe('Apex Replay Debugger', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);

--- a/test/specs/debugApexTests.e2e.ts
+++ b/test/specs/debugApexTests.e2e.ts
@@ -28,14 +28,14 @@ describe('Debug Apex Tests', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
-    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Override Conflicts successfully ran".
+    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Ignore Conflicts successfully ran".
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);

--- a/test/specs/runApexTests.e2e.ts
+++ b/test/specs/runApexTests.e2e.ts
@@ -30,14 +30,14 @@ describe('Run Apex Tests', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
-    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Override Conflicts successfully ran".
+    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Ignore Conflicts successfully ran".
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
@@ -202,14 +202,14 @@ describe('Run Apex Tests', async () => {
     // Push source to org
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
-    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Override Conflicts successfully ran".
+    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Ignore Conflicts successfully ran".
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
@@ -411,14 +411,14 @@ describe('Run Apex Tests', async () => {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
-    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Override Conflicts successfully ran".
+    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Ignore Conflicts successfully ran".
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
@@ -461,14 +461,14 @@ describe('Run Apex Tests', async () => {
     // Push source to org
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
-    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Override Conflicts successfully ran".
+    // Look for the success notification that appears which says, "SFDX: Push Source to Default Org and Ignore Conflicts successfully ran".
     const successPushNotification2WasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotification2WasFound).toBe(true);

--- a/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/test/specs/trailApexReplayDebugger.e2e.ts
@@ -30,13 +30,13 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);
@@ -254,13 +254,13 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', async
     // Push source to org
     await utilities.runCommandFromCommandPrompt(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts',
+      'SFDX: Push Source to Default Org and Ignore Conflicts',
       1
     );
 
     const successPushNotificationWasFound = await utilities.notificationIsPresentWithTimeout(
       workbench,
-      'SFDX: Push Source to Default Org and Override Conflicts successfully ran',
+      'SFDX: Push Source to Default Org and Ignore Conflicts successfully ran',
       utilities.TEN_MINUTES
     );
     expect(successPushNotificationWasFound).toBe(true);


### PR DESCRIPTION
In our SFDX -> SF for Push Source PR (https://github.com/forcedotcom/salesforcedx-vscode/pull/5362), we changed the command in the command palette from `SFDX: Push Source to Default Org and Override Conflicts` to `SFDX: Push Source to Default Org and Ignore Conflicts` to be consistent with the customer-facing flag and the setting name changes.  Because of that change, the E2E tests for last night's Nightly Build Develop were failing because the command `SFDX: Push Source to Default Org and Override Conflicts` could not be found.

In this PR, all the places where `SFDX: Push Source to Default Org and Override Conflicts` were called now call `SFDX: Push Source to Default Org and Ignore Conflicts` instead.

Passing Test Run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7712903688