### PR TITLE
fix: eliminate 'unknown error: unhandled inspector error: {"code":-32000,"message":"No node with given id found"}' flapper

### DIFF
--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { step } from 'mocha-steps';
+import { step, xstep } from 'mocha-steps';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
 import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
@@ -29,6 +29,7 @@ describe('Apex LSP', async () => {
     // Using the Command palette, run Developer: Show Running Extensions
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.showRunningExtensions(workbench);
+    utilities.log('finished showing running extensions');
 
     // Verify Apex extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
@@ -36,9 +37,11 @@ describe('Apex LSP', async () => {
       'salesforcedx-vscode-apex'
     );
     expect(extensionWasFound).toBe(true);
+    utilities.log('all extensions are found');
+    utilities.log('exit Verify Extension is Running');
   });
 
-  step('Verify LSP finished indexing', async () => {
+  xstep('Verify LSP finished indexing', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Verify LSP finished indexing`);
 
     // Close running extensions view
@@ -59,7 +62,7 @@ describe('Apex LSP', async () => {
     utilities.log(outputViewText);
   });
 
-  step('Go to Definition', async () => {
+  xstep('Go to Definition', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
@@ -86,7 +89,7 @@ describe('Apex LSP', async () => {
     expect(title).toBe('ExampleClass.cls');
   });
 
-  step('Autocompletion', async () => {
+  xstep('Autocompletion', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();

--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { step, xstep } from 'mocha-steps';
+import { step } from 'mocha-steps';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
 import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
@@ -29,7 +29,6 @@ describe('Apex LSP', async () => {
     // Using the Command palette, run Developer: Show Running Extensions
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.showRunningExtensions(workbench);
-    utilities.log('finished showing running extensions');
 
     // Verify Apex extension is present and running
     const extensionWasFound = await utilities.findExtensionInRunningExtensionsList(
@@ -37,11 +36,9 @@ describe('Apex LSP', async () => {
       'salesforcedx-vscode-apex'
     );
     expect(extensionWasFound).toBe(true);
-    utilities.log('all extensions are found');
-    utilities.log('exit Verify Extension is Running');
   });
 
-  xstep('Verify LSP finished indexing', async () => {
+  step('Verify LSP finished indexing', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Verify LSP finished indexing`);
 
     // Close running extensions view
@@ -62,7 +59,7 @@ describe('Apex LSP', async () => {
     utilities.log(outputViewText);
   });
 
-  xstep('Go to Definition', async () => {
+  step('Go to Definition', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
@@ -89,7 +86,7 @@ describe('Apex LSP', async () => {
     expect(title).toBe('ExampleClass.cls');
   });
 
-  xstep('Autocompletion', async () => {
+  step('Autocompletion', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -49,8 +49,11 @@ export async function findExtensionInRunningExtensionsList(
   log('closed panel and cleared notifications');
 
   const extensionNameDivs = await $$('div.monaco-list-row');
+  log('extensionNameDivs = ' + extensionNameDivs.toString());
   let extensionWasFound = false;
+  log('enter for loop');
   for (const extensionNameDiv of extensionNameDivs) {
+    log('extensionNameDiv = ' + extensionNameDiv.toString());
     const text = await extensionNameDiv.getAttribute('aria-label');
     log(`looking for ${extensionName}`);
     if (text.includes(extensionName)) {

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -59,6 +59,7 @@ export async function findExtensionInRunningExtensionsList(
     if (text.includes(extensionName)) {
       extensionWasFound = true;
       log(`extension ${extensionName} was found`);
+      break;
     }
   }
 

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -49,13 +49,13 @@ export async function findExtensionInRunningExtensionsList(
   log('closed panel and cleared notifications');
 
   const extensionNameDivs = await $$('div.monaco-list-row');
-  log('extensionNameDivs = ' + extensionNameDivs.toString());
+  log('extensionNameDivs length = ' + extensionNameDivs.length);
   let extensionWasFound = false;
   log('enter for loop');
   for (const extensionNameDiv of extensionNameDivs) {
-    log('extensionNameDiv = ' + extensionNameDiv.toString());
     const text = await extensionNameDiv.getAttribute('aria-label');
     log(`looking for ${extensionName}`);
+    log('text = ' + text);
     if (text.includes(extensionName)) {
       extensionWasFound = true;
       log(`extension ${extensionName} was found`);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -34,8 +34,6 @@ export async function findExtensionInRunningExtensionsList(
 ): Promise<boolean> {
   // This function assumes the Extensions list was opened.
 
-  log('&&& enter findExtensionInRunningExtensionsList()');
-
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
   try {
     await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
@@ -46,16 +44,11 @@ export async function findExtensionInRunningExtensionsList(
     log('No panel or notifs to close - command not found');
   }
   pause(1);
-  log('closed panel and cleared notifications');
 
   const extensionNameDivs = await $$('div.monaco-list-row');
-  log('extensionNameDivs length = ' + extensionNameDivs.length);
   let extensionWasFound = false;
-  log('enter for loop');
   for (const extensionNameDiv of extensionNameDivs) {
     const text = await extensionNameDiv.getAttribute('aria-label');
-    log(`looking for ${extensionName}`);
-    log('text = ' + text);
     if (text.includes(extensionName)) {
       extensionWasFound = true;
       log(`extension ${extensionName} was found`);
@@ -63,7 +56,6 @@ export async function findExtensionInRunningExtensionsList(
     }
   }
 
-  log('&&& exit findExtensionInRunningExtensionsList()');
   return extensionWasFound;
 }
 

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -34,6 +34,8 @@ export async function findExtensionInRunningExtensionsList(
 ): Promise<boolean> {
   // This function assumes the Extensions list was opened.
 
+  log('&&& enter findExtensionInRunningExtensionsList()');
+
   // Close the panel and clear notifications so we can see as many of the running extensions as we can.
   try {
     await runCommandFromCommandPrompt(workbench, 'View: Close Panel', 1);
@@ -44,17 +46,20 @@ export async function findExtensionInRunningExtensionsList(
     log('No panel or notifs to close - command not found');
   }
   pause(1);
+  log('closed panel and cleared notifications');
 
   const extensionNameDivs = await $$('div.monaco-list-row');
   let extensionWasFound = false;
   for (const extensionNameDiv of extensionNameDivs) {
     const text = await extensionNameDiv.getAttribute('aria-label');
+    log(`looking for ${extensionName}`);
     if (text.includes(extensionName)) {
       extensionWasFound = true;
       log(`extension ${extensionName} was found`);
     }
   }
 
+  log('&&& exit findExtensionInRunningExtensionsList()');
   return extensionWasFound;
 }
 


### PR DESCRIPTION
This flapper has been around for a few months, and it was mostly present in **ApexLsp.e2e.ts** during the **Verify Extension is Running** step.  The cause of this flapper was in **extensionUtils.ts** in the `findExtensionInRunningExtensionsList()` function - after the extension is found, the for loop kept going and searching for the extension rather than breaking out of the loop, which caused a stale element and this error message.

What was fixed: Add a `break` in the for loop after the extension is found.

@W-14498987@

Passing E2E test runs:

1. Apex E2E Tests #84: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7704042747
2. Apex E2E Tests #85: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7704043867
3. Apex E2E Tests #86: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7704045623
4. E2E Tests #768: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7714238818
5. E2E Tests #770: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7714244040