### PR TITLE
fix: Aura E2E Test runs on VSIXs

### DIFF
--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -74,7 +74,7 @@ describe('Aura LSP', async () => {
     expect(definition[1]).toBe(27);
   });
 
-  xstep('Autocompletion', async () => {
+  step('Autocompletion', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Autocompletion`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -19,6 +19,10 @@ describe('Aura LSP', async () => {
 
     // Create Aura Component
     await utilities.createAura('aura1');
+
+    // Reload the VSCode window to allow the Aura Component to be indexed by the Aura Language Server
+    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.runCommandFromCommandPrompt(workbench, 'Developer: Reload Window', 70);
   });
 
   step('Verify Extension is Running', async () => {

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -69,10 +69,17 @@ describe('Aura LSP', async () => {
     await utilities.pause(1);
 
     // Verify 'Go to definition'
-    const definition = await textEditor.getCoordinates();
-    utilities.log('{auraLsp.e2e.ts Go to Definition} typeof(definition) = [' + typeof(definition) + ']');
-    expect(definition[0]).toBe(3);
-    expect(definition[1]).toBe(27);
+    // This workaround types text in the place where the cursor is located after the Go to Definition is complete, and then verifies that the added text is present in the correct location.
+    await browser.keys('elephant');
+    await browser.keys([CMD_KEY, 's']);
+    await utilities.pause(1);
+    const line3Text = await textEditor.getTextAtLine(2);
+    expect(line3Text).toContain('name="elephantsimpleNewContact"');
+
+    // The following code uses WDIO's provided function to get the position of the cursor, but `textEditor.getCoordinates();` causes a `coordinates is not iterable` error in Ubuntu. Thus we have to use the workaround above instead.
+    // const definition = await textEditor.getCoordinates();
+    // expect(definition[0]).toBe(3);
+    // expect(definition[1]).toBe(27);
   });
 
   step('Autocompletion', async () => {

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -70,9 +70,9 @@ describe('Aura LSP', async () => {
 
     // Verify 'Go to definition'
     const definition = await textEditor.getCoordinates();
-    // expect(definition[0]).toBe(3);
-    // expect(definition[1]).toBe(27);
-    expect(definition).toEqual([3, 27]);
+    utilities.log('{auraLsp.e2e.ts Go to Definition} typeof(definition) = [' + typeof(definition) + ']');
+    expect(definition[0]).toBe(3);
+    expect(definition[1]).toBe(27);
   });
 
   step('Autocompletion', async () => {

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -70,8 +70,9 @@ describe('Aura LSP', async () => {
 
     // Verify 'Go to definition'
     const definition = await textEditor.getCoordinates();
-    expect(definition[0]).toBe(3);
-    expect(definition[1]).toBe(27);
+    // expect(definition[0]).toBe(3);
+    // expect(definition[1]).toBe(27);
+    expect(definition).toEqual([3, 27]);
   });
 
   step('Autocompletion', async () => {

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { step, xstep } from 'mocha-steps';
+import { step } from 'mocha-steps';
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities';
 import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
@@ -87,7 +87,15 @@ describe('Aura LSP', async () => {
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();
     const textEditor = await utilities.getTextEditor(workbench, 'aura1.cmp');
-    await textEditor.typeTextAt(2, 1, '<aura:appl');
+    // Workaround for `coordinates is not iterable` error is needed here too because `textEditor.typeTextAt()` uses coordinates.
+    await browser.keys([CMD_KEY, 'f']);
+    await utilities.pause(1);
+    await browser.keys('aura:attribute');
+    await browser.keys(['Escape']);
+    await browser.keys(['ArrowRight']);
+    await browser.keys(['ArrowUp']);
+    await browser.keys('<aura:appl');
+    // await textEditor.typeTextAt(2, 1, '<aura:appl');
     await utilities.pause(1);
 
     // Verify autocompletion options are present

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -73,7 +73,7 @@ describe('Aura LSP', async () => {
     await browser.keys('elephant');
     await browser.keys([CMD_KEY, 's']);
     await utilities.pause(1);
-    const line3Text = await textEditor.getTextAtLine(2);
+    const line3Text = await textEditor.getTextAtLine(3);
     expect(line3Text).toContain('name="elephantsimpleNewContact"');
 
     // The following code uses WDIO's provided function to get the position of the cursor, but `textEditor.getCoordinates();` causes a `coordinates is not iterable` error in Ubuntu. Thus we have to use the workaround above instead.

--- a/test/specs/auraLsp.e2e.ts
+++ b/test/specs/auraLsp.e2e.ts
@@ -46,7 +46,7 @@ describe('Aura LSP', async () => {
     utilities.log(outputViewText);
   });
 
-  xstep('Go to Definition', async () => {
+  step('Go to Definition', async () => {
     utilities.log(`${testSetup.testSuiteSuffixName} - Go to Definition`);
     // Get open text editor
     const workbench = await (await browser.getWorkbench()).wait();


### PR DESCRIPTION
This PR contains fixes for flappers in the Aura E2E test that prevent it from running successfully on VSIXs.

What got fixed:
1. The Aura LSP indexes existing Aura files when the Aura extension is activated, but the Aura component that we use for Go to Definition did not get indexed because it was created after the indexing happened.  I added a reload after the Aura component is created so that the Aura LSP would restart and redo the indexing, capturing the new component.
2. The `textEditor.getCoordinates()` function call in Go to Definition and the `textEditor.typeTextAt()` function call in Autocompletion cause a `coordinates is not iterable` error when the E2E test is run on Ubuntu.  This PR contains workarounds using `browser.keys()` to recreate the same functionality and get around the issue.

Passing E2E test runs:
1. https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/8575950666 ✅ 
3. https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/8576151245 ✅ 

@W-14385264@