### PR TITLE
fix: turn off setting to auto update extensions

### DIFF
--- a/test/specs/miscellaneous.e2e.ts
+++ b/test/specs/miscellaneous.e2e.ts
@@ -99,10 +99,13 @@ describe('Miscellaneous', async () => {
 
     // Type snippet "lwc-button" and check it inserted the right lwc
     const textEditor = await utilities.getTextEditor(workbench, 'lwc.html');
+
+    await utilities.runCommandFromCommandPrompt(workbench, 'Snippets: Insert Snippet', 1);
     await browser.keys(['lwc-button']);
     await utilities.pause(2);
-    await browser.keys(['ArrowDown']);
     await browser.keys(['Enter']);
+    await browser.keys(['Escape']);
+    await textEditor.save();
     const fileContent = await textEditor.getText();
 
     const fileContentWithoutTrailingSpaces = fileContent

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -12,7 +12,6 @@ import util from 'util';
 import { DefaultTreeItem, InputBox, QuickOpenBox, Workbench } from 'wdio-vscode-service';
 import { EnvironmentSettings } from './environmentSettings';
 import * as utilities from './utilities';
-import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
 
 const exec = util.promisify(child_process.exec);
 
@@ -48,7 +47,6 @@ export class TestSetup {
     await utilities.verifyAllExtensionsAreRunning();
     await this.authorizeDevHub();
     await this.createDefaultScratchOrg();
-    await this.disableCommandCenter();
     utilities.log(`${this.testSuiteSuffixName} - ...finished TestSetup.setUp()`);
     utilities.log('');
   }
@@ -58,26 +56,6 @@ export class TestSetup {
       // The Terminal view can be a bit unreliable, so directly call exec() instead:
       await exec(`sf org:delete:scratch --target-org ${this.scratchOrgAliasName} --no-prompt`);
     }
-  }
-
-  public async disableCommandCenter(): Promise<void> {
-    const workbench = await (await browser.getWorkbench()).wait();
-    await utilities.runCommandFromCommandPrompt(workbench, 'Preferences: Open User Settings', 3);
-    await browser.keys(['Window: Command Center']);
-    await utilities.pause(3);
-    expect(1).toBe(2);
-
-    const commandCenterBtn = await utilities.findElementByText(
-      'div',
-      'title',
-      'window.commandCenter'
-    );
-    await commandCenterBtn.click();
-    await utilities.pause(3);
-
-    // Close settings tab
-    await browser.keys([CMD_KEY, 'w']);
-    await utilities.pause(1);
   }
 
   public async setUpTestingEnvironment(): Promise<void> {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -63,7 +63,7 @@ export class TestSetup {
   public async disableCommandCenter(): Promise<void> {
     const workbench = await (await browser.getWorkbench()).wait();
     await utilities.runCommandFromCommandPrompt(workbench, 'Preferences: Open User Settings', 3);
-    await browser.keys(['autoupdate']);
+    await browser.keys(['Window: Command Center']);
     await utilities.pause(3);
     expect(1).toBe(2);
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -62,13 +62,10 @@ export class TestSetup {
 
   public async disableCommandCenter(): Promise<void> {
     const workbench = await (await browser.getWorkbench()).wait();
-    await utilities.runCommandFromCommandPrompt(
-      workbench,
-      'Preferences: Open Workspace Settings',
-      3
-    );
-    await browser.keys(['Window: Command Center']);
+    await utilities.runCommandFromCommandPrompt(workbench, 'Preferences: Open User Settings', 3);
+    await browser.keys(['autoupdate']);
     await utilities.pause(3);
+    expect(1).toBe(2);
 
     const commandCenterBtn = await utilities.findElementByText(
       'div',

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -25,6 +25,10 @@ const capabilities: VSCodeCapabilities = {
       force: true,
       installExtension: EnvironmentSettings.getInstance().extensionPath,
       extensionsDir: EnvironmentSettings.getInstance().extensionPath
+    },
+    userSettings: {
+      'extensions.autoUpdate': false,
+      'window.commandCenter': false
     }
   } as VSCodeOptions,
 


### PR DESCRIPTION
Disable auto-update in vscode for e2e tests

- Modifies LWC HTML snippets insertion from Command Palette instead of typing for more accuracy
- Gets rid of `disableCommandCenter()` in favor of `'window.commandCenter': false` in wdio.conf.ts
- Sets `'extensions.autoUpdate': false` in wdio.conf.ts with `VSCodeOptions.userSettings` property

[W-15736459](https://gus.lightning.force.com/a07EE00001rB6zQYAS)