### PR TITLE
feat: check for uncaught errors in Running Extensions view at the end of each suite

### DIFF
--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -110,18 +110,6 @@ describe('An Initial Suite', async () => {
     await utilities.pause(1);
   });
 
-  step('Check for uncaught errors', async () => {
-    // Zoom out so all the extensions are visible
-    const workbench = await (await browser.getWorkbench()).wait();
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
-    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
-    const uncaughtErrors = await $$('span.codicon-bug');
-    utilities.log(`${uncaughtErrors.length} uncaught errors were found`);
-    expect(uncaughtErrors.length).toBe(0);
-  });
-
   xstep(
     'Verify that SFDX commands are present after an SFDX project has been created',
     async () => {

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -110,6 +110,18 @@ describe('An Initial Suite', async () => {
     await utilities.pause(1);
   });
 
+  step('Check for uncaught errors', async () => {
+    // Zoom out so all the extensions are visible
+    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    const uncaughtErrors = await $$('span.codicon-bug');
+    utilities.log(`${uncaughtErrors.length} uncaught errors were found`);
+    expect(uncaughtErrors.length).toBe(0);
+  });
+
   xstep(
     'Verify that SFDX commands are present after an SFDX project has been created',
     async () => {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -69,7 +69,11 @@ export class TestSetup {
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
     await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
     const uncaughtErrors = await $$('span.codicon-bug');
-    utilities.log(`${uncaughtErrors.length} uncaught errors were found`);
+    utilities.log(
+      uncaughtErrors.length == 1
+        ? `${uncaughtErrors.length} extension with uncaught errors was found`
+        : `${uncaughtErrors.length} extensions with uncaught errors were found`
+    );
     expect(uncaughtErrors.length).toBe(0);
   }
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -52,10 +52,25 @@ export class TestSetup {
   }
 
   public async tearDown(): Promise<void> {
+    await this.checkForUncaughtErrors();
     if (this.scratchOrgAliasName && !this.reuseScratchOrg) {
       // The Terminal view can be a bit unreliable, so directly call exec() instead:
       await exec(`sf org:delete:scratch --target-org ${this.scratchOrgAliasName} --no-prompt`);
     }
+  }
+
+  private async checkForUncaughtErrors(): Promise<void> {
+    const workbench = await (await browser.getWorkbench()).wait();
+    await utilities.showRunningExtensions(workbench);
+
+    // Zoom out so all the extensions are visible
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    await utilities.runCommandFromCommandPrompt(workbench, 'View: Zoom Out', 1);
+    const uncaughtErrors = await $$('span.codicon-bug');
+    utilities.log(`${uncaughtErrors.length} uncaught errors were found`);
+    expect(uncaughtErrors.length).toBe(0);
   }
 
   public async setUpTestingEnvironment(): Promise<void> {


### PR DESCRIPTION
In this PR we add a check for uncaught errors as part of the tearDown step that runs at the end of each test suite

[W-15471367](https://gus.lightning.force.com/a07EE00001oEl72YAC)

Test run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9321356263/job/25660154165 ✅ 