### PR TITLE
chore: do not install Salesforce Extension Pack and Salesforce Extension Pack Expanded in E2E

### DIFF
--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -84,7 +84,7 @@ describe('An Initial Suite', async () => {
       }
     }
 
-    expect(expectedSfdxCommandsFound).toBe(5);
+    expect(expectedSfdxCommandsFound).toBe(3);
     expect(unexpectedSfdxCommandWasFound).toBe(false);
 
     // Escape out of the pick list.

--- a/test/specs/anInitialSuite.e2e.ts
+++ b/test/specs/anInitialSuite.e2e.ts
@@ -71,8 +71,6 @@ describe('An Initial Suite', async () => {
         case 'SFDX: Create and Set Up Project for ISV Debugging':
         case 'SFDX: Create Project':
         case 'SFDX: Create Project with Manifest':
-        case 'SLDS: Do not scope SLDS Validator to SFDX project files':
-        case 'SLDS: Scope SLDS Validator to run for SFDX project files':
           expectedSfdxCommandsFound++;
           break;
 

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -99,7 +99,7 @@ export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
   for (const extension of extensions) {
     log('extension = ' + extension);
-    if (!extension.includes('salesforcedx-vscode-expanded-')) {
+    if (!extension.includes('salesforcedx-vscode-expanded')) {
       await installExtension(extension);
       log('installed ' + extension);
     }

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -98,8 +98,10 @@ export async function installExtension(extension: string): Promise<void> {
 export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
   for (const extension of extensions) {
+    log('extension = ' + extension);
     if (!extension.includes('salesforcedx-vscode-expanded-')) {
       await installExtension(extension);
+      log('installed ' + extension);
     }
   }
   await pause(FIVE_MINUTES);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -99,7 +99,7 @@ export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
   for (const extension of extensions) {
     log('extension = ' + extension);
-    if (!extension.includes('salesforcedx-vscode-expanded')) {
+    if ((extension !== 'salesforcedx-vscode-expanded') && (extension !== 'salesforcedx-vscode')) {
       await installExtension(extension);
       log('installed ' + extension);
     }

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -97,8 +97,11 @@ export async function installExtension(extension: string): Promise<void> {
 
 export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
+  const pattern = /^salesforcedx-vscode-expanded-\d+\.\d+\.\d+\.vsix$/;
   for (const extension of extensions) {
-    await installExtension(extension);
+    if (!pattern.test(extension)) {
+      await installExtension(extension);
+    }
   }
   await pause(FIVE_MINUTES);
   await runCommandFromCommandPrompt(workbench, 'Extensions: Enable All Extensions', 5);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -12,8 +12,6 @@ import { CMD_KEY } from 'wdio-vscode-service/dist/constants';
 import path from 'path';
 
 const extensions: string[] = [
-  'salesforcedx-vscode',
-  'salesforcedx-vscode-expanded',
   'salesforcedx-vscode-soql',
   'salesforcedx-vscode-core',
   'salesforcedx-vscode-apex',
@@ -98,11 +96,7 @@ export async function installExtension(extension: string): Promise<void> {
 export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
   for (const extension of extensions) {
-    log('extension = ' + extension);
-    if ((extension !== 'salesforcedx-vscode-expanded') && (extension !== 'salesforcedx-vscode')) {
-      await installExtension(extension);
-      log('installed ' + extension);
-    }
+    await installExtension(extension);
   }
   await pause(FIVE_MINUTES);
   await runCommandFromCommandPrompt(workbench, 'Extensions: Enable All Extensions', 5);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -97,9 +97,8 @@ export async function installExtension(extension: string): Promise<void> {
 
 export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
-  const pattern = /\S.*expanded\S.*$/;
   for (const extension of extensions) {
-    if (!pattern.test(extension)) {
+    if (!extension.includes('salesforcedx-vscode-expanded-')) {
       await installExtension(extension);
     }
   }

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -97,7 +97,7 @@ export async function installExtension(extension: string): Promise<void> {
 
 export async function installExtensions(): Promise<void> {
   const workbench = await (await browser.getWorkbench()).wait();
-  const pattern = /^salesforcedx-vscode-expanded-\d+\.\d+\.\d+\.vsix$/;
+  const pattern = /\S.*expanded\S.*$/;
   for (const extension of extensions) {
     if (!pattern.test(extension)) {
       await installExtension(extension);


### PR DESCRIPTION
To avoid an uncaught error in the ESLint extension (which the LWC extension is no longer dependent on) the E2E tests now only install the Salesforce extensions individually, without any extension packs that contain third-party extensions.  This workaround will take place until we complete the migration of E2E tests to ESM and can start testing on the latest VSCode version.

@W-16084277@

E2E test run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9702077940
_Note: There are some flappers during the extensions VSIX installation process but all the E2E tests except AnInitialSuite pass for at least 2 OS's.  (AnInitialSuite keeps on flapping during the tear down step.)_