### PR TITLE
fix: make e2e tests run past setup step on windows

### DIFF
--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -30,12 +30,12 @@ describe('Apex LSP', async () => {
 
     // Using the Command palette, run Developer: Show Running Extensions
     await utilities.showRunningExtensions();
-    utilities.zoom('Out', 4, 1);
+    await utilities.zoom('Out', 4, 1);
     // Verify Apex extension is present and running
     const foundExtensions = await utilities.findExtensionsInRunningExtensionsList([
       'salesforcedx-vscode-apex'
     ]);
-    utilities.zoomReset();
+    await utilities.zoomReset();
     expect(foundExtensions.length).toBe(1);
   });
 

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -367,11 +367,7 @@ export class TestSetup {
 
     // Run SFDX: Set a Default Org
     utilities.log(`${this.testSuiteSuffixName} - selecting SFDX: Set a Default Org...`);
-    const inputBox = await utilities.runCommandFromCommandPrompt(
-      workbench,
-      'SFDX: Set a Default Org',
-      10
-    );
+    const inputBox = await utilities.executeQuickPick('SFDX: Set a Default Org', 10);
 
     utilities.log(`${this.testSuiteSuffixName} - calling findQuickPickItem()...`);
     const scratchOrgQuickPickItemWasFound = await utilities.findQuickPickItem(

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -268,7 +268,9 @@ export class TestSetup {
     );
   }
 
-  private async createDefaultScratchOrg(edition: utilities.OrgEdition = 'developer'): Promise<void> {
+  private async createDefaultScratchOrg(
+    edition: utilities.OrgEdition = 'developer'
+  ): Promise<void> {
     utilities.log('');
     utilities.log(`${this.testSuiteSuffixName} - Starting createDefaultScratchOrg()...`);
 
@@ -283,7 +285,7 @@ export class TestSetup {
 
       const sfOrgListResult = await exec('sf org:list --json');
       const resultJson = this.removedEscapedCharacters(sfOrgListResult.stdout);
-      const scratchOrgs = JSON.parse(resultJson).result.scratchOrgs as {alias: string}[];
+      const scratchOrgs = JSON.parse(resultJson).result.scratchOrgs as { alias: string }[];
 
       const foundScratchOrg = scratchOrgs.find((scratchOrg) => {
         const alias = scratchOrg.alias as string;
@@ -420,11 +422,7 @@ export class TestSetup {
   }
 
   private async setDefaultOrg(workbench: Workbench): Promise<void> {
-    const inputBox = await utilities.runCommandFromCommandPrompt(
-      workbench,
-      'SFDX: Set a Default Org',
-      2
-    );
+    const inputBox = await utilities.executeQuickPick('SFDX: Set a Default Org', 2);
 
     const scratchOrgQuickPickItemWasFound = await utilities.findQuickPickItem(
       inputBox,

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { TextEditor } from 'wdio-vscode-service';
-import { executeQuickPick, runCommandFromCommandPrompt } from './commandPrompt.ts';
+import { executeQuickPick } from './commandPrompt.ts';
 import { getTextEditor, pause } from './miscellaneous.ts';
 
 export async function createApexClass(

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -108,7 +108,7 @@ export async function createAnonymousApexFile(): Promise<void> {
   const editorView = workbench.getEditorView();
 
   // Using the Command palette, run File: New File...
-  const inputBox = await runCommandFromCommandPrompt(workbench, 'Create: New File...', 1);
+  const inputBox = await executeQuickPick('Create: New File...', 1);
 
   // Set the name of the new Anonymous Apex file
   await inputBox.setText('Anonymous.apex');

--- a/test/utilities/apexUtils.ts
+++ b/test/utilities/apexUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { TextEditor } from 'wdio-vscode-service';
-import { runCommandFromCommandPrompt } from './commandPrompt.ts';
+import { executeQuickPick, runCommandFromCommandPrompt } from './commandPrompt.ts';
 import { getTextEditor, pause } from './miscellaneous.ts';
 
 export async function createApexClass(
@@ -17,7 +17,7 @@ export async function createApexClass(
   const workbench = await (await browser.getWorkbench()).wait();
 
   // Using the Command palette, run SFDX: Create Apex Class to create the main class
-  const inputBox = await runCommandFromCommandPrompt(workbench, 'SFDX: Create Apex Class', 1);
+  const inputBox = await executeQuickPick('SFDX: Create Apex Class', 1);
 
   // Set the name of the new Apex Class
   await inputBox.setText(name);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -234,7 +234,7 @@ export async function installExtensions(excludeExtensions: ExtensionId[] = []): 
       .basename(vsix)
       .match(/^(?<extension>.*?)(-(?<version>\d+\.\d+\.\d+))?\.vsix$/);
     if (match?.groups) {
-      const { extension } = match.groups;
+      const { extension, version } = match.groups;
       const foundExtension = extensions.find((e) => e.extensionId === extension);
       if (foundExtension) {
         foundExtension.vsixPath = vsix;
@@ -245,7 +245,9 @@ export async function installExtensions(excludeExtensions: ExtensionId[] = []): 
         // if not installing, don't verify, otherwise use default value
         foundExtension.shouldVerifyActivation =
           foundExtension.shouldInstall === 'never' ? false : foundExtension.shouldVerifyActivation;
-        log(`SetUp - Found extension ${extension} with vsixPath ${foundExtension.vsixPath}`);
+        log(
+          `SetUp - Found extension ${extension} version ${version} with vsixPath ${foundExtension.vsixPath}`
+        );
       }
     }
   });

--- a/test/utilities/miscellaneous.ts
+++ b/test/utilities/miscellaneous.ts
@@ -9,7 +9,7 @@ import os from 'os';
 import { TextEditor, Workbench, sleep } from 'wdio-vscode-service';
 import { EnvironmentSettings } from '../environmentSettings.ts';
 import { attemptToFindOutputPanelText } from './outputView.ts';
-import { runCommandFromCommandPrompt } from './commandPrompt.ts';
+import { executeQuickPick } from './commandPrompt.ts';
 import { notificationIsPresentWithTimeout } from './notifications.ts';
 import path from 'path';
 
@@ -66,7 +66,7 @@ export async function findElementByText(
  * @returns editor for the given file name
  */
 export async function getTextEditor(workbench: Workbench, fileName: string): Promise<TextEditor> {
-  const inputBox = await runCommandFromCommandPrompt(workbench, 'Go to File...', 1);
+  const inputBox = await executeQuickPick('Go to File...', 1);
   await inputBox.setText(fileName);
   await inputBox.confirm();
   await pause(1);
@@ -82,8 +82,8 @@ export async function createCommand(
   extension: string
 ): Promise<string | undefined> {
   const workbench = await (await browser.getWorkbench()).wait();
-  await runCommandFromCommandPrompt(workbench, 'View: Clear Output', 1);
-  const inputBox = await runCommandFromCommandPrompt(workbench, `SFDX: Create ${type}`, 1);
+  await executeQuickPick('View: Clear Output', 1);
+  const inputBox = await executeQuickPick(`SFDX: Create ${type}`, 1);
 
   // Set the name of the new component to name.
   await inputBox.setText(name);

--- a/test/utilities/outputView.ts
+++ b/test/utilities/outputView.ts
@@ -8,7 +8,7 @@
 import clipboard from 'clipboardy';
 import { pause } from './miscellaneous.ts';
 import { dismissAllNotifications } from './notifications.ts';
-import { runCommandFromCommandPrompt } from './commandPrompt.ts';
+import { executeQuickPick } from './commandPrompt.ts';
 
 import { Key } from 'webdriverio';
 const CMD_KEY = process.platform === 'darwin' ? Key.Command : Key.Control;
@@ -27,8 +27,7 @@ export async function selectOutputChannel(name: string): Promise<void> {
   await dismissAllNotifications();
 
   // Find the given channel in the Output view
-  const workbench = await (await browser.getWorkbench()).wait();
-  await runCommandFromCommandPrompt(workbench, 'Output: Show Output Channels...', 1);
+  await executeQuickPick('Output: Show Output Channels...', 1);
   await browser.keys([name, 'Enter']);
   await pause(2);
 }
@@ -40,8 +39,7 @@ export async function getOutputViewText(outputChannelName: string = ''): Promise
   }
 
   // Set focus to the contents in the Output panel.
-  const workbench = await (await browser.getWorkbench()).wait();
-  await runCommandFromCommandPrompt(workbench, 'Output: Focus on Output View', 2);
+  await executeQuickPick('Output: Focus on Output View', 2);
 
   // Select all of the text within the panel.
   await browser.keys([CMD_KEY, 'a', 'c']);


### PR DESCRIPTION
E2E tests were always failing with `Error: Quick pick item SFDX: Set a Default Org was not found` on windows. Tests can now run past that point and eventually (considering flappers like the rest of os's) make it to tear down.

@W-16164065@

[Test run](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9812786679)