### PR TITLE
feat: add support for running E2E tests on VSCode version 1.86.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "husky": "9.0.11",
         "mocha-steps": "^1.3.0",
         "prettier": "3.2.5",
+        "semver": "^7.6.3",
         "ts-node": "10.9.2",
         "typescript": "5.3.3",
         "wdio-vscode-service": "6.1.0",
@@ -1156,33 +1157,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
@@ -1296,33 +1270,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.1.tgz",
@@ -1346,33 +1293,6 @@
       },
       "peerDependencies": {
         "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -1464,33 +1384,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@vscode/test-electron/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@vscode/test-electron/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@wdio/cli": {
@@ -4859,33 +4752,6 @@
         "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/eslint-plugin-compat/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
@@ -5523,33 +5389,6 @@
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
       "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
       "dev": true
-    },
-    "node_modules/fastify/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fastify/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -7970,6 +7809,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -8372,33 +8220,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/normalize-path": {
@@ -10046,12 +9867,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-error": {
@@ -11595,12 +11419,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "husky": "9.0.11",
     "mocha-steps": "^1.3.0",
     "prettier": "3.2.5",
+    "semver": "^7.6.3",
     "ts-node": "10.9.2",
     "typescript": "5.3.3",
     "wdio-vscode-service": "6.1.0",

--- a/test/specs/miscellaneous.e2e.ts
+++ b/test/specs/miscellaneous.e2e.ts
@@ -42,20 +42,13 @@ describe('Miscellaneous', async () => {
 
     // Using the Command palette, run Snippets: Configure Snippets
     const workbench = await utilities.getWorkbench();
-    if (
-      EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
-      semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.92.0')
-    ) {
-      await utilities.executeQuickPick(
-        'Snippets: Configure Snippets',
-        utilities.Duration.seconds(1)
-      );
-    } else {
-      await utilities.executeQuickPick(
-        'Snippets: Configure User Snippets',
-        utilities.Duration.seconds(1)
-      );
-    }
+  const commandName =
+    EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
+    semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.92.0')
+      ? 'Snippets: Configure Snippets'
+      : 'Snippets: Configure User Snippets';
+
+  await utilities.executeQuickPick(commandName, utilities.Duration.seconds(1));
     await browser.keys(['New Global Snippets file...', 'Enter']);
     await utilities.pause(utilities.Duration.seconds(1));
     await browser.keys(['apex.json', 'Enter']);

--- a/test/specs/miscellaneous.e2e.ts
+++ b/test/specs/miscellaneous.e2e.ts
@@ -42,13 +42,13 @@ describe('Miscellaneous', async () => {
 
     // Using the Command palette, run Snippets: Configure Snippets
     const workbench = await utilities.getWorkbench();
-  const commandName =
-    EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
-    semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.92.0')
-      ? 'Snippets: Configure Snippets'
-      : 'Snippets: Configure User Snippets';
+    const commandName =
+      EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
+      semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.92.0')
+        ? 'Snippets: Configure Snippets'
+        : 'Snippets: Configure User Snippets';
 
-  await utilities.executeQuickPick(commandName, utilities.Duration.seconds(1));
+    await utilities.executeQuickPick(commandName, utilities.Duration.seconds(1));
     await browser.keys(['New Global Snippets file...', 'Enter']);
     await utilities.pause(utilities.Duration.seconds(1));
     await browser.keys(['apex.json', 'Enter']);

--- a/test/specs/miscellaneous.e2e.ts
+++ b/test/specs/miscellaneous.e2e.ts
@@ -7,6 +7,8 @@
 import { step, xstep } from 'mocha-steps';
 import { TestSetup } from '../testSetup.ts';
 import * as utilities from '../utilities/index.ts';
+import * as semver from 'semver';
+import { EnvironmentSettings } from '../environmentSettings.ts';
 
 describe('Miscellaneous', async () => {
   let testSetup: TestSetup;
@@ -40,10 +42,20 @@ describe('Miscellaneous', async () => {
 
     // Using the Command palette, run Snippets: Configure Snippets
     const workbench = await utilities.getWorkbench();
-    await utilities.executeQuickPick(
-      'Snippets: Configure Snippets',
-      utilities.Duration.seconds(1)
-    );
+    if (
+      EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
+      semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.92.0')
+    ) {
+      await utilities.executeQuickPick(
+        'Snippets: Configure Snippets',
+        utilities.Duration.seconds(1)
+      );
+    } else {
+      await utilities.executeQuickPick(
+        'Snippets: Configure User Snippets',
+        utilities.Duration.seconds(1)
+      );
+    }
     await browser.keys(['New Global Snippets file...', 'Enter']);
     await utilities.pause(utilities.Duration.seconds(1));
     await browser.keys(['apex.json', 'Enter']);

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -142,15 +142,13 @@ export async function showRunningExtensions(): Promise<void> {
   await utilities.executeQuickPick('Developer: Show Running Extensions');
   await browser.waitUntil(
     async () => {
-      let runningExtensionsTab;
+      const selector =
+        EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
+        semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.90.0')
+          ? "//div[contains(@class, 'active') and contains(@class, 'selected') and .//*[contains(text(), 'Running Extensions')]]"
+          : "//div[contains(@class, 'monaco-list-row') and .//*[contains(text(), 'Running Extensions')]]";
 
-  const selector =
-    EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
-    semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.90.0')
-      ? "//div[contains(@class, 'active') and contains(@class, 'selected') and .//*[contains(text(), 'Running Extensions')]]"
-      : "//div[contains(@class, 'monaco-list-row') and .//*[contains(text(), 'Running Extensions')]]";
-
-  runningExtensionsTab = await $(selector);
+      const runningExtensionsTab = await $(selector);
       return (await runningExtensionsTab.getTitle()).includes('Running Extensions');
     },
     {

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -143,18 +143,14 @@ export async function showRunningExtensions(): Promise<void> {
   await browser.waitUntil(
     async () => {
       let runningExtensionsTab;
-      if (
-        EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
-        semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.90.0')
-      ) {
-        runningExtensionsTab = await $(
-          "//div[contains(@class, 'active') and contains(@class, 'selected') and .//*[contains(text(), 'Running Extensions')]]"
-        );
-      } else {
-        runningExtensionsTab = await $(
-          "//div[contains(@class, 'monaco-list-row') and .//*[contains(text(), 'Running Extensions')]]"
-        );
-      }
+
+  const selector =
+    EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
+    semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.90.0')
+      ? "//div[contains(@class, 'active') and contains(@class, 'selected') and .//*[contains(text(), 'Running Extensions')]]"
+      : "//div[contains(@class, 'monaco-list-row') and .//*[contains(text(), 'Running Extensions')]]";
+
+  runningExtensionsTab = await $(selector);
       return (await runningExtensionsTab.getTitle()).includes('Running Extensions');
     },
     {

--- a/test/utilities/extensionUtils.ts
+++ b/test/utilities/extensionUtils.ts
@@ -12,6 +12,7 @@ import FastGlob from 'fast-glob';
 import { EnvironmentSettings } from '../environmentSettings.ts';
 import { exec } from 'child_process';
 import * as utilities from './index.ts';
+import * as semver from 'semver';
 
 export type ExtensionId =
   | 'salesforcedx-vscode'
@@ -141,10 +142,20 @@ export async function showRunningExtensions(): Promise<void> {
   await utilities.executeQuickPick('Developer: Show Running Extensions');
   await browser.waitUntil(
     async () => {
-      const runningExtensionsTab = await $(
-        "//div[contains(@class, 'active') and contains(@class, 'selected') and .//*[contains(text(), 'Running Extensions')]]"
-      );
-      return runningExtensionsTab.isDisplayed();
+      let runningExtensionsTab;
+      if (
+        EnvironmentSettings.getInstance().vscodeVersion === 'stable' ||
+        semver.gte(EnvironmentSettings.getInstance().vscodeVersion, '1.90.0')
+      ) {
+        runningExtensionsTab = await $(
+          "//div[contains(@class, 'active') and contains(@class, 'selected') and .//*[contains(text(), 'Running Extensions')]]"
+        );
+      } else {
+        runningExtensionsTab = await $(
+          "//div[contains(@class, 'monaco-list-row') and .//*[contains(text(), 'Running Extensions')]]"
+        );
+      }
+      return (await runningExtensionsTab.getTitle()).includes('Running Extensions');
     },
     {
       timeout: 5000, // Timeout after 5 seconds


### PR DESCRIPTION
Made the following changes to get E2E tests running on our new minimum supported VSCode version 1.86.0:
1. Checks for the Running Extensions tab in a different selector based on whether VSCode version is >=1.90.0
2. Checks for "Snippets: Configure Snippets" vs. "Snippets: Configure User Snippets" based on whether VSCode version is >=1.92.0

@W-16361200@

E2E test runs:
1. stable: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/10325834691
2. 1.86.0: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/10325829201